### PR TITLE
Added placeholder test html so tests run

### DIFF
--- a/packages/perspective-viewer-d3fc/test/html/bar.html
+++ b/packages/perspective-viewer-d3fc/test/html/bar.html
@@ -1,0 +1,41 @@
+<!--
+   
+   Copyright (c) 2017, the Perspective Authors.
+   
+   This file is part of the Perspective library, distributed under the terms of
+   the Apache License 2.0.  The full license can be found in the LICENSE file.
+
+-->
+
+<!DOCTYPE html>
+<html>
+    <head>
+
+        <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
+        <script src="perspective.view.js"></script>
+        <script src="d3fc.plugin.js"></script>
+
+        <link rel='stylesheet' href="demo.css">
+
+    </head>
+    <body>
+
+        <perspective-viewer
+            view="d3_y_bar"
+            columns='["Sales"]'>
+  
+        </perspective-viewer>
+
+        <script>
+
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', 'superstore.csv', true);
+            xhr.onload = function () { 
+                document.getElementsByTagName('perspective-viewer')[0].load(xhr.response); 
+            }
+            xhr.send(null);
+
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
The tests start with an initial step that copies files from the `/test/html` folder of each of the packages. However, since the D3FC folder was missing, it failed.

I've added the folder and a placeholder `bar.html` to allow the test command to succeed, though of course there are no D3FC tests yet.

Note that the following command now works for me (in unix) - 417 tests pass, 13 skipped:

    PSP_DOCKER=1 yarn test
