### PR TITLE
IPJS-2 add non breaking space to main label to stop it wrapping

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/d3fcChart.js
+++ b/packages/perspective-viewer-d3fc/src/js/d3fcChart.js
@@ -11,6 +11,8 @@ import * as d3 from "d3";
 import {configureLegend, configureBarSeries, configureGrid, configureScale, configureMultiSvg, configureChart} from "./chartConfig";
 import {interpretLabels, interpretGroupBys, interpretDataset} from "./dataInterpretation";
 
+const nbsp = "\xa0";
+
 export default class D3FCChart {
     constructor(mode, config, container) {
         this._mode = mode;
@@ -134,7 +136,7 @@ function styleChart(chart, horizontal, labels) {
         return horizontal ? `translate(${parallelToAxis}, ${perpendicularToAxis})` : `translate(${perpendicularToAxis}, ${parallelToAxis})`;
     }
 
-    mainLabel(labels.mainLabel.join(", "));
+    mainLabel(labels.mainLabel.join(`,${nbsp}`));
     //crossLabel(labels.crossLabel); // not enabled.
 
     let textDistanceFromXAxis = 9;


### PR DESCRIPTION
Adding a non-breaking space stops the Y-axis labels from going across lines