### PR TITLE
Remove hidden data before render

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -61,8 +61,8 @@ function removeHiddenData(col, hidden) {
                 delete col[key];
             }
         });
-        return col;
     }
+    return col;
 }
 
 function createOrUpdateChart(div, chart, settings) {


### PR DESCRIPTION
e.g. if sort by "Profit", but don't include "Profit" in the chart, perspective will include "Profit" in the data anyway, but add it to the "hidden" list. At the moment, there doesn't seem to be a reason to keep it in the data