### PR TITLE
Minimum 1-pixel bandwidth

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
@@ -8,6 +8,8 @@
  */
 import * as d3 from "d3";
 import * as fc from "d3fc";
+import minBandwidth from "./minBandwidth";
+import withoutTicks from "./withoutTicks";
 
 const AXIS_TYPES = {
     none: "none",
@@ -19,26 +21,23 @@ const AXIS_TYPES = {
 export const scale = settings => {
     switch (axisType(settings)) {
         case AXIS_TYPES.none:
-            return scaleBandWithoutTicks();
+            return withoutTicks(defaultScaleBand());
         case AXIS_TYPES.time:
             return d3.scaleTime();
         case AXIS_TYPES.linear:
             return d3.scaleLinear();
         default:
-            return d3.scaleBand().padding(0.5);
+            return defaultScaleBand();
     }
 };
+
+const defaultScaleBand = () => minBandwidth(d3.scaleBand().padding(0.5));
 
 export const domain = settings => {
     const accessData = extent => {
         return extent.accessors([labelFunction(settings)])(settings.data);
     };
     switch (axisType(settings)) {
-        // case AXIS_TYPES.none: {
-        //     const d = accessData(fc.extentLinear());
-        //     console.log(d);
-        //     return d;
-        // }
         case AXIS_TYPES.time:
             return accessData(fc.extentTime());
         case AXIS_TYPES.linear:
@@ -72,12 +71,4 @@ const axisType = settings => {
         }
     }
     return AXIS_TYPES.ordinal;
-};
-
-const scaleBandWithoutTicks = () => {
-    const scale = d3.scaleBand().padding(0.5);
-    scale.ticks = function() {
-        return [];
-    };
-    return scale;
 };

--- a/packages/perspective-viewer-d3fc/src/js/axis/minBandwidth.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/minBandwidth.js
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {rebindAll} from "d3fc";
+
+const MIN_BANDWIDTH = 1;
+
+export default adaptee => {
+    const minBandwidth = arg => {
+        return adaptee(arg);
+    };
+
+    rebindAll(minBandwidth, adaptee);
+
+    minBandwidth.bandwidth = (...args) => {
+        if (!args.length) {
+            return Math.max(adaptee.bandwidth(), MIN_BANDWIDTH);
+        }
+        adaptee.bandwidth(...args);
+        return minBandwidth;
+    };
+
+    return minBandwidth;
+};

--- a/packages/perspective-viewer-d3fc/src/js/axis/withoutTicks.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/withoutTicks.js
@@ -1,0 +1,23 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {rebindAll} from "d3fc";
+
+export default adaptee => {
+    const withoutTicks = arg => {
+        return adaptee(arg);
+    };
+
+    rebindAll(withoutTicks, adaptee);
+
+    withoutTicks.ticks = function() {
+        return [];
+    };
+
+    return withoutTicks;
+};


### PR DESCRIPTION
Avoids lines disappearing because they are too narrow (only works for scaleBand).
Also improved implementation of `withoutTicks` band.

Uses d3fc-style adaptors.