### PR TITLE
Moved the getChartElement helper into a new module

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/legend/legend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/legend.js
@@ -7,7 +7,7 @@
  *
  */
 import * as d3Legend from "d3-svg-legend";
-import {getChartElement} from "../plugin/plugin";
+import {getChartElement} from "../plugin/root";
 
 export function legend(container, settings, colour) {
     if (colour) {

--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -96,7 +96,3 @@ function deleteChart() {
         perspective_d3fc_element.delete();
     }
 }
-
-export function getChartElement(element) {
-    return element.getRootNode().host;
-}

--- a/packages/perspective-viewer-d3fc/src/js/plugin/root.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/root.js
@@ -1,0 +1,12 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+export function getChartElement(element) {
+    return element.getRootNode().host;
+}


### PR DESCRIPTION
If it's in plugin.js, then anything importing it also has to import all the chart stuff