### PR TITLE
rename '[d3fc] Y Line Chart 2' to '[d3fc] Y Line Chart'

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/line.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/line.js
@@ -36,8 +36,8 @@ function lineChart(container, settings) {
     container.datum(data).call(chart);
 }
 lineChart.plugin = {
-    type: "d3_y_line_2",
-    name: "[d3fc] Y Line Chart 2",
+    type: "d3_y_line",
+    name: "[d3fc] Y Line Chart",
     maxRenderSize: 25000
 };
 


### PR DESCRIPTION
Remove the "2" from the name of [d3fc] Y Line Chart