### PR TITLE
Space ticks correctly and hide main axis line

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
@@ -19,16 +19,19 @@ const AXIS_TYPES = {
 };
 
 export const scale = settings => {
+    let _scale;
     switch (axisType(settings)) {
         case AXIS_TYPES.none:
-            return withoutTicks(defaultScaleBand());
+            _scale = withoutTicks(defaultScaleBand());
         case AXIS_TYPES.time:
-            return d3.scaleTime();
+            _scale = d3.scaleTime();
         case AXIS_TYPES.linear:
-            return d3.scaleLinear();
+            _scale = d3.scaleLinear();
         default:
-            return defaultScaleBand();
+            _scale = defaultScaleBand();
     }
+
+    return _scale.paddingInner(0.4).paddingOuter(0.2);
 };
 
 const defaultScaleBand = () => minBandwidth(d3.scaleBand());

--- a/packages/perspective-viewer-d3fc/src/js/charts/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/bar.js
@@ -14,6 +14,7 @@ import {seriesColours} from "../series/seriesColours";
 import {groupAndStackData} from "../data/groupAndStackData";
 import {legend, filterData} from "../legend/legend";
 import {withGridLines} from "../gridlines/gridlines";
+import {applyStyleToDOM} from "../domStyling/bar";
 
 function barChart(container, settings) {
     const data = groupAndStackData(settings, filterData(settings));
@@ -41,6 +42,8 @@ function barChart(container, settings) {
         .plotArea(withGridLines(series).orient("horizontal"));
 
     chart.yPadding && chart.yPadding(0.5);
+
+    applyStyleToDOM(chart);
 
     // render
     container.datum(data).call(chart);

--- a/packages/perspective-viewer-d3fc/src/js/charts/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/bar.js
@@ -41,7 +41,7 @@ function barChart(container, settings) {
         .yLabel(crossAxis.label(settings))
         .plotArea(withGridLines(series).orient("horizontal"));
 
-    chart.yPadding && chart.yPadding(0.5);
+    //chart.yPadding && chart.yPadding(0.5);
 
     applyStyleToDOM(chart);
 

--- a/packages/perspective-viewer-d3fc/src/js/charts/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/column.js
@@ -41,7 +41,7 @@ function columnChart(container, settings) {
         .yLabel(mainAxis.label(settings))
         .plotArea(withGridLines(series).orient("vertical"));
 
-    chart.xPadding && chart.xPadding(0.5);
+    //chart.xPadding && chart.xPadding(0.5); //todo: why was this here specifically?
 
     applyStyleToDOM(chart);
 

--- a/packages/perspective-viewer-d3fc/src/js/charts/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/column.js
@@ -14,6 +14,7 @@ import {seriesColours} from "../series/seriesColours";
 import {groupAndStackData} from "../data/groupAndStackData";
 import {legend, filterData} from "../legend/legend";
 import {withGridLines} from "../gridlines/gridlines";
+import {applyStyleToDOM} from "../domStyling/column";
 
 function columnChart(container, settings) {
     const data = groupAndStackData(settings, filterData(settings));
@@ -41,6 +42,8 @@ function columnChart(container, settings) {
         .plotArea(withGridLines(series).orient("vertical"));
 
     chart.xPadding && chart.xPadding(0.5);
+
+    applyStyleToDOM(chart);
 
     // render
     container.datum(data).call(chart);

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
@@ -1,0 +1,15 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {decorateAxis} from "./decorateMainAxis";
+
+export function applyStyleToDOM(chart) {
+    const mainDecorate = chart.xDecorate;
+    decorateMainAxis(mainDecorate);
+}

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
@@ -7,9 +7,40 @@
  *
  */
 
-import {decorateAxis} from "./decorateMainAxis";
+import {decorateMainAxis} from "./decorateMainAxis";
+import {calculateTickSpacing, mutateCrossAxisText} from "./decorateCrossAxis";
+
+const TICK_LENGTH = 18;
+const LABEL_TICK_PADDING = -2;
 
 export function applyStyleToDOM(chart) {
-    const mainDecorate = chart.xDecorate;
+    const [mainDecorate, crossDecorate] = [chart.xDecorate, chart.yDecorate];
     decorateMainAxis(mainDecorate);
+    decorateCrossAxis(crossDecorate);
+}
+
+function decorateCrossAxis(crossDecorate) {
+    function translate(y, x) {
+        return `translate(${x}, ${y})`;
+    }
+
+    crossDecorate(axis => {
+        let groups = axis._groups[0];
+        let parent = axis._parents[0];
+
+        axis.attr("transform", "translate(0, 0)"); //correctly align ticks on the crossAxis for subsequent mutations
+
+        const tickSpacing = calculateTickSpacing(parent, groups, "height");
+        const textDistanceFromAxis = -TICK_LENGTH - LABEL_TICK_PADDING;
+        mutateCrossAxisText(axis, tickSpacing, textDistanceFromAxis, translate);
+
+        mutateCrossAxisTicks(axis, tickSpacing, translate, TICK_LENGTH);
+    });
+}
+
+function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength) {
+    axis.select("path") // select the tick marks
+        .attr("stroke", "rgb(187, 187, 187)")
+        .attr("d", `M0,0L-${standardTickLength},0`)
+        .attr("transform", (x, i) => translate(i * tickSpacing, 0));
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
@@ -1,0 +1,16 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import * as fc from "d3fc";
+import {decorateMainAxis} from "./decorateMainAxis";
+
+export function applyStyleToDOM(chart) {
+    const mainDecorate = chart.yDecorate;
+    decorateMainAxis(mainDecorate);
+}

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
@@ -7,10 +7,40 @@
  *
  */
 
-import * as fc from "d3fc";
 import {decorateMainAxis} from "./decorateMainAxis";
+import {calculateTickSpacing, mutateCrossAxisText} from "./decorateCrossAxis";
+
+const TICK_LENGTH = 9;
+const LABEL_TICK_PADDING = 2;
 
 export function applyStyleToDOM(chart) {
-    const mainDecorate = chart.yDecorate;
+    const [mainDecorate, crossDecorate] = [chart.yDecorate, chart.xDecorate];
     decorateMainAxis(mainDecorate);
+    decorateCrossAxis(crossDecorate);
+}
+
+function decorateCrossAxis(crossDecorate) {
+    function translate(x, y) {
+        return `translate(${x}, ${y})`;
+    }
+
+    crossDecorate(axis => {
+        let groups = axis._groups[0];
+        let parent = axis._parents[0];
+
+        axis.attr("transform", "translate(0, 0)"); //correctly align ticks on the crossAxis for subsequent mutations
+
+        const tickSpacing = calculateTickSpacing(parent, groups, "width");
+        const textDistanceFromAxis = TICK_LENGTH + LABEL_TICK_PADDING;
+        mutateCrossAxisText(axis, tickSpacing, textDistanceFromAxis, translate);
+
+        mutateCrossAxisTicks(axis, tickSpacing, translate, TICK_LENGTH);
+    });
+}
+
+function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength) {
+    axis.select("path") // select the tick marks
+        .attr("stroke", "rgb(187, 187, 187)")
+        .attr("d", `M0,0L0,${standardTickLength}`)
+        .attr("transform", (x, i) => translate(i * tickSpacing, 0));
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
@@ -1,0 +1,31 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+export function calculateTickSpacing(parent, groups, axisDimension) {
+    let parentViewBoxVals = parent.attributes.viewBox.value.split(" ");
+    let viewBoxDimensionMappings = {x: 0, y: 1, width: 2, height: 3};
+    let totalSpace = parentViewBoxVals[viewBoxDimensionMappings[axisDimension]];
+
+    let tickSpacing = totalSpace / groups.length;
+    return tickSpacing;
+}
+
+export function mutateCrossAxisText(axis, tickSpacing, distanceFromAxis, translate) {
+    axis.select("text")
+        .attr("transform", (_, i) => translate(i * tickSpacing + tickSpacing / 2, distanceFromAxis))
+        .text(content => returnOnlyMostSubdividedGroup(content));
+}
+
+function returnOnlyMostSubdividedGroup(content) {
+    if (!Array.isArray(content)) {
+        return content;
+    }
+    let lastElement = content[content.length - 1];
+    return lastElement;
+}

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/decorateMainAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/decorateMainAxis.js
@@ -1,0 +1,27 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+export function decorateMainAxis(mainDecorate) {
+    mainDecorate(axis => {
+        hideMainAxisLine(axis);
+        hideMainAxisTicks(axis);
+    });
+
+    return;
+}
+
+function hideMainAxisTicks(axis) {
+    axis.select("path") // select the tick marks
+        .attr("display", "none");
+}
+
+function hideMainAxisLine(axis) {
+    let parent = axis._parents[0];
+    parent.firstChild.setAttribute("display", "none");
+}


### PR DESCRIPTION
I'd imagine to rename the domStyling folder, and follow the typicaly naming schema I'm seeing in general, so "column" becomes "columnStyling" for example.

Also, there's a couple commented out bits of code left in, because I was curious as to their purpose. Specifically line 44 in packages/perspective-viewer-d3fc/src/js/charts/bar.js and the same for .../charts/column.js.