### PR TITLE
DO NOT MERGE - Feature/multi layer labels on group by

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/bar.js
@@ -43,7 +43,7 @@ function barChart(container, settings) {
 
     //chart.yPadding && chart.yPadding(0.5);
 
-    applyStyleToDOM(chart);
+    applyStyleToDOM(chart, settings.crossValues.map(x => x.name), settings.data);
 
     // render
     container.datum(data).call(chart);

--- a/packages/perspective-viewer-d3fc/src/js/charts/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/column.js
@@ -43,7 +43,7 @@ function columnChart(container, settings) {
 
     //chart.xPadding && chart.xPadding(0.5); //todo: why was this here specifically?
 
-    applyStyleToDOM(chart);
+    applyStyleToDOM(chart, settings.crossValues.map(x => x.name), settings.data);
 
     // render
     container.datum(data).call(chart);

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
@@ -9,20 +9,20 @@
 
 import {decorateMainAxis} from "./decorateMainAxis";
 import {calculateTickSpacing, mutateCrossAxisText, addCrossAxisLabelsForNestedGroupBys, tickLength} from "./decorateCrossAxis";
-import {CrossAxisMap} from "./crossAxisMap";
+import {GroupByLayerTopography} from "./groupByLayerTopography";
 
 const TICK_LENGTH = 18;
 const LABEL_TICK_PADDING = -2;
 
 export function applyStyleToDOM(chart, crossLabels, data) {
-    let crossAxisMap = new CrossAxisMap(crossLabels, data);
+    let groupByLayerTopography = new GroupByLayerTopography(crossLabels, data);
 
     const [mainDecorate, crossDecorate] = [chart.xDecorate, chart.yDecorate];
     decorateMainAxis(mainDecorate);
-    decorateCrossAxis(crossDecorate, crossAxisMap, TICK_LENGTH, LABEL_TICK_PADDING);
+    decorateCrossAxis(crossDecorate, groupByLayerTopography, TICK_LENGTH, LABEL_TICK_PADDING);
 }
 
-function decorateCrossAxis(crossDecorate, crossAxisMap, tickLength, labelTickPadding) {
+function decorateCrossAxis(crossDecorate, groupByLayerTopography, tickLength, labelTickPadding) {
     function translate(y, x) {
         return `translate(${x}, ${y})`;
     }
@@ -37,15 +37,15 @@ function decorateCrossAxis(crossDecorate, crossAxisMap, tickLength, labelTickPad
         const textDistanceFromAxis = -tickLength - labelTickPadding;
         mutateCrossAxisText(axis, tickSpacing, textDistanceFromAxis, translate);
 
-        mutateCrossAxisTicks(axis, tickSpacing, translate, tickLength, crossAxisMap);
+        mutateCrossAxisTicks(axis, tickSpacing, translate, tickLength, groupByLayerTopography);
 
-        addCrossAxisLabelsForNestedGroupBys(crossAxisMap, groups, true);
+        addCrossAxisLabelsForNestedGroupBys(groupByLayerTopography, groups, true);
     });
 }
 
-function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength, crossAxisMap) {
+function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength, groupByLayerTopography) {
     axis.select("path") // select the tick marks
         .attr("stroke", "rgb(187, 187, 187)")
-        .attr("d", (d, i) => `M0,0L-${tickLength(standardTickLength, i, crossAxisMap)},0`)
+        .attr("d", (d, i) => `M0,0L-${tickLength(standardTickLength, i, groupByLayerTopography)},0`)
         .attr("transform", (x, i) => translate(i * tickSpacing, 0));
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/bar.js
@@ -8,18 +8,21 @@
  */
 
 import {decorateMainAxis} from "./decorateMainAxis";
-import {calculateTickSpacing, mutateCrossAxisText} from "./decorateCrossAxis";
+import {calculateTickSpacing, mutateCrossAxisText, addCrossAxisLabelsForNestedGroupBys, tickLength} from "./decorateCrossAxis";
+import {CrossAxisMap} from "./crossAxisMap";
 
 const TICK_LENGTH = 18;
 const LABEL_TICK_PADDING = -2;
 
-export function applyStyleToDOM(chart) {
+export function applyStyleToDOM(chart, crossLabels, data) {
+    let crossAxisMap = new CrossAxisMap(crossLabels, data);
+
     const [mainDecorate, crossDecorate] = [chart.xDecorate, chart.yDecorate];
     decorateMainAxis(mainDecorate);
-    decorateCrossAxis(crossDecorate);
+    decorateCrossAxis(crossDecorate, crossAxisMap, TICK_LENGTH, LABEL_TICK_PADDING);
 }
 
-function decorateCrossAxis(crossDecorate) {
+function decorateCrossAxis(crossDecorate, crossAxisMap, tickLength, labelTickPadding) {
     function translate(y, x) {
         return `translate(${x}, ${y})`;
     }
@@ -31,16 +34,18 @@ function decorateCrossAxis(crossDecorate) {
         axis.attr("transform", "translate(0, 0)"); //correctly align ticks on the crossAxis for subsequent mutations
 
         const tickSpacing = calculateTickSpacing(parent, groups, "height");
-        const textDistanceFromAxis = -TICK_LENGTH - LABEL_TICK_PADDING;
+        const textDistanceFromAxis = -tickLength - labelTickPadding;
         mutateCrossAxisText(axis, tickSpacing, textDistanceFromAxis, translate);
 
-        mutateCrossAxisTicks(axis, tickSpacing, translate, TICK_LENGTH);
+        mutateCrossAxisTicks(axis, tickSpacing, translate, tickLength, crossAxisMap);
+
+        addCrossAxisLabelsForNestedGroupBys(crossAxisMap, groups, true);
     });
 }
 
-function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength) {
+function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength, crossAxisMap) {
     axis.select("path") // select the tick marks
         .attr("stroke", "rgb(187, 187, 187)")
-        .attr("d", `M0,0L-${standardTickLength},0`)
+        .attr("d", (d, i) => `M0,0L-${tickLength(standardTickLength, i, crossAxisMap)},0`)
         .attr("transform", (x, i) => translate(i * tickSpacing, 0));
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/column.js
@@ -9,20 +9,20 @@
 
 import {decorateMainAxis} from "./decorateMainAxis";
 import {calculateTickSpacing, mutateCrossAxisText, addCrossAxisLabelsForNestedGroupBys, tickLength} from "./decorateCrossAxis";
-import {CrossAxisMap} from "./crossAxisMap";
+import {GroupByLayerTopography} from "./groupByLayerTopography";
 
 const TICK_LENGTH = 9;
 const LABEL_TICK_PADDING = 2;
 
 export function applyStyleToDOM(chart, crossLabels, data) {
-    let crossAxisMap = new CrossAxisMap(crossLabels, data);
+    let groupByLayerTopography = new GroupByLayerTopography(crossLabels, data);
 
     const [mainDecorate, crossDecorate] = [chart.yDecorate, chart.xDecorate];
     decorateMainAxis(mainDecorate);
-    decorateCrossAxis(crossDecorate, crossAxisMap, TICK_LENGTH, LABEL_TICK_PADDING);
+    decorateCrossAxis(crossDecorate, groupByLayerTopography, TICK_LENGTH, LABEL_TICK_PADDING);
 }
 
-function decorateCrossAxis(crossDecorate, crossAxisMap, tickLength, labelTickPadding) {
+function decorateCrossAxis(crossDecorate, groupByLayerTopography, tickLength, labelTickPadding) {
     function translate(x, y) {
         return `translate(${x}, ${y})`;
     }
@@ -37,15 +37,15 @@ function decorateCrossAxis(crossDecorate, crossAxisMap, tickLength, labelTickPad
         const textDistanceFromAxis = tickLength + labelTickPadding;
         mutateCrossAxisText(axis, tickSpacing, textDistanceFromAxis, translate);
 
-        mutateCrossAxisTicks(axis, tickSpacing, translate, tickLength, crossAxisMap);
+        mutateCrossAxisTicks(axis, tickSpacing, translate, tickLength, groupByLayerTopography);
 
-        addCrossAxisLabelsForNestedGroupBys(crossAxisMap, groups, false);
+        addCrossAxisLabelsForNestedGroupBys(groupByLayerTopography, groups, false);
     });
 }
 
-function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength, crossAxisMap) {
+function mutateCrossAxisTicks(axis, tickSpacing, translate, standardTickLength, groupByLayerTopography) {
     axis.select("path") // select the tick marks
         .attr("stroke", "rgb(187, 187, 187)")
-        .attr("d", (x, i) => `M0,0L0,${tickLength(standardTickLength, i, crossAxisMap)}`)
+        .attr("d", (x, i) => `M0,0L0,${tickLength(standardTickLength, i, groupByLayerTopography)}`)
         .attr("transform", (x, i) => translate(i * tickSpacing, 0));
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/crossAxisMap.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/crossAxisMap.js
@@ -1,0 +1,219 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import {isNullOrUndefined} from "util";
+let LABEL_TICK_PADDING = 2;
+let STANDARD_TICK_LENGTH = 9;
+const HORIZONTAL_STANDARD_TICK_LENGTH = -18;
+const HORIZONTAL_LABEL_TICK_PADDING = -2;
+
+export class CrossAxisMap {
+    constructor(crossLabels, dataset) {
+        this._map = this.generateMap(crossLabels, dataset);
+    }
+
+    get map() {
+        return this._map;
+    }
+
+    get levelCount() {
+        return this._map.length;
+    }
+
+    generateMap(crossLabels, dataset) {
+        let levelMap = [];
+
+        for (let levelIndex = 0; levelIndex < crossLabels.length; levelIndex++) {
+            let parentLevel = levelIndex === 0 ? null : levelMap[levelIndex - 1];
+            let level = new Level(crossLabels[levelIndex], parentLevel, levelIndex);
+
+            let workingNode;
+            dataset.forEach((dataPoint, dpIndex) => {
+                let dpLevelVal = dataPoint.__ROW_PATH__[levelIndex];
+                if (dpIndex === 0) {
+                    let parentNode = levelIndex === 0 ? null : parentLevel.nodes[0];
+                    workingNode = new LevelNode(dpLevelVal, parentNode, levelIndex);
+                    workingNode.addTick(dpIndex);
+                    return;
+                }
+
+                if (workingNode.name === dpLevelVal) {
+                    if (workingNode.canShareParentage(dpIndex)) {
+                        workingNode.addTick(dpIndex);
+                        return;
+                    }
+                }
+
+                level.addNode(workingNode);
+                let parentNode = levelIndex === 0 ? null : parentLevel.nodeWithTick(dpIndex);
+                workingNode = new LevelNode(dpLevelVal, parentNode, levelIndex);
+                workingNode.addTick(dpIndex);
+                return;
+            });
+
+            level.addNode(workingNode);
+            levelMap.push(level);
+        }
+
+        console.log("levelMap: ", levelMap);
+        return levelMap;
+    }
+
+    calculateLabelPositions(tickList, horizontal) {
+        let labelsMappedToTicks = this._map
+            .map(level => level.nodes.map(node => node.calculateLabelPosition(tickList, this._map.length, horizontal)))
+            .flat()
+            .filter(mapping => !isNullOrUndefined(mapping));
+
+        return labelsMappedToTicks;
+    }
+}
+
+class Level {
+    constructor(name, parentLevel, levelIndex) {
+        this._name = name;
+        this._parentLevel = parentLevel;
+        this._levelIndex = levelIndex;
+        this._levelNodes = [];
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get nodes() {
+        return this._levelNodes;
+    }
+
+    get parentLevel() {
+        return this._parentLevel;
+    }
+
+    get levelIndex() {
+        return this._levelIndex;
+    }
+
+    isTopLevel() {
+        return this._parentLevel === null;
+    }
+
+    addNode(node) {
+        this._levelNodes.push(node);
+    }
+
+    nodeWithTick(tickIndex) {
+        return this._levelNodes.filter(node => node.nodeContainsTick(tickIndex))[0];
+    }
+}
+
+class LevelNode {
+    constructor(name, parentNode, levelIndex) {
+        this._name = name;
+        this._parentNode = parentNode;
+        this._levelIndex = levelIndex;
+        this._ticks = [];
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get parentNode() {
+        return this._parentNode;
+    }
+
+    get ticks() {
+        return this._ticks;
+    }
+
+    isTopLevel() {
+        return this._parentNode === null;
+    }
+
+    addTick(tickIndex) {
+        this._ticks.push(tickIndex);
+    }
+
+    nodeContainsTick(tickIndex) {
+        return this._ticks.includes(tickIndex);
+    }
+
+    canShareParentage(proposedChildTickIndex) {
+        return this.isTopLevel() || this._parentNode.nodeContainsTick(proposedChildTickIndex);
+    }
+
+    calculateLabelPosition(tickList, totalLevels, horizontal) {
+        let middleTickIndex = Math.round((this._ticks.length + 1) / 2) - 1;
+        let middleTick = this._ticks[middleTickIndex];
+
+        if (this._levelIndex === totalLevels - 1) {
+            return;
+        }
+
+        let levelDepth = totalLevels - this._levelIndex;
+
+        // eslint-disable-next-line prettier/prettier
+        let result = this._ticks.length % 2 !== 1
+                ? placeLabelOnTick(middleTick, tickList, this._name, levelDepth, horizontal)
+                : placeLabelInSpaceBesideTick(middleTick, tickList, this._name, levelDepth, horizontal);
+
+        return result;
+    }
+}
+
+function placeLabelOnTick(tickIndex, tickList, labelText, labelDepth, horizontal) {
+    let tickElement = tickList[tickIndex];
+    let tickStroke = tickElement.firstChild;
+
+    // eslint-disable-next-line prettier/prettier
+    let [horizontalOffset, verticalOffset] = horizontal 
+        ? calculateXGraphLabelOffsets(tickStroke, labelDepth) 
+        : calculateYGraphLabelOffsets(tickStroke, labelDepth);
+
+    return cloneThenModifyLabel(tickElement, horizontalOffset, verticalOffset, labelText);
+}
+
+function placeLabelInSpaceBesideTick(tickIndex, tickList, labelText, labelDepth, horizontal) {
+    let tickElement = tickList[tickIndex];
+    let tickBaseText = tickElement.childNodes[1];
+
+    // eslint-disable-next-line prettier/prettier
+    let [horizontalOffset, verticalOffset] = horizontal 
+        ? calculateXGraphLabelOffsets(tickBaseText, labelDepth) 
+        : calculateYGraphLabelOffsets(tickBaseText, labelDepth);
+
+    return cloneThenModifyLabel(tickElement, horizontalOffset, verticalOffset, labelText);
+}
+
+function calculateYGraphLabelOffsets(baseElement, labelDepth) {
+    let baseElementTransform = baseElement.attributes.transform.value;
+
+    let horizontalOffset = baseElementTransform.substring(baseElementTransform.lastIndexOf("(") + 1, baseElementTransform.lastIndexOf(","));
+    let verticalDepthMultiplied = STANDARD_TICK_LENGTH * labelDepth;
+    let verticalOffset = verticalDepthMultiplied + LABEL_TICK_PADDING;
+
+    return [horizontalOffset, verticalOffset];
+}
+
+function calculateXGraphLabelOffsets(baseElement, labelDepth) {
+    let baseElementTransform = baseElement.attributes.transform.value;
+
+    let verticalOffset = baseElementTransform.substring(baseElementTransform.lastIndexOf(",") + 1, baseElementTransform.lastIndexOf(")"));
+    let horizontalDepthMultiplied = HORIZONTAL_STANDARD_TICK_LENGTH * labelDepth;
+    let horizontalOffset = horizontalDepthMultiplied + HORIZONTAL_LABEL_TICK_PADDING;
+
+    return [horizontalOffset, verticalOffset];
+}
+
+function cloneThenModifyLabel(tickElement, horizontalOffset, verticalOffset, labelText) {
+    let clone = tickElement.childNodes[1].cloneNode(true);
+    clone.setAttribute("transform", `translate(${horizontalOffset}, ${verticalOffset})`);
+    clone.textContent = labelText;
+    return {tick: tickElement, label: clone};
+}

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
@@ -24,7 +24,19 @@ export function mutateCrossAxisText(axis, tickSpacing, distanceFromAxis, transla
 
 export function addCrossAxisLabelsForNestedGroupBys(crossAxisMap, groups, horizontal) {
     let groupByLabelsToAppend = crossAxisMap.calculateLabelPositions(groups, horizontal);
-    groupByLabelsToAppend.forEach(labelTick => labelTick.tick.appendChild(labelTick.label));
+    groupByLabelsToAppend.forEach(labelTick => {
+        removePreExistingNestedLabel(labelTick);
+        labelTick.tick.appendChild(labelTick.label);
+    });
+}
+
+function removePreExistingNestedLabel(labelTick) {
+    for (let i = 0; i < labelTick.tick.children.length; i++) {
+        if (labelTick.tick.children[i].innerHTML === labelTick.label.innerHTML) {
+            let preExistingNode = labelTick.tick.children[i];
+            labelTick.tick.removeChild(preExistingNode);
+        }
+    }
 }
 
 function returnOnlyMostSubdividedGroup(content) {
@@ -36,16 +48,16 @@ function returnOnlyMostSubdividedGroup(content) {
     return lastElement;
 }
 
-export function tickLength(standardTickLength, tickIndex, crossAxisMap) {
+export function tickLength(standardTickLength, tickIndex, groupByLayerTopography) {
     const multiplier = standardTickLength;
 
     // ticks are shorter in the case where we're not dubdividing by groups.
-    if (crossAxisMap.length <= 1) {
+    if (groupByLayerTopography.length <= 1) {
         return multiplier / 3;
     }
 
     let depth = 1;
-    crossAxisMap.map.forEach(level => {
+    groupByLayerTopography.map.forEach(level => {
         if (level.nodeWithTick(tickIndex).ticks[0] === tickIndex) {
             depth++;
         }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/decorateCrossAxis.js
@@ -22,10 +22,34 @@ export function mutateCrossAxisText(axis, tickSpacing, distanceFromAxis, transla
         .text(content => returnOnlyMostSubdividedGroup(content));
 }
 
+export function addCrossAxisLabelsForNestedGroupBys(crossAxisMap, groups, horizontal) {
+    let groupByLabelsToAppend = crossAxisMap.calculateLabelPositions(groups, horizontal);
+    groupByLabelsToAppend.forEach(labelTick => labelTick.tick.appendChild(labelTick.label));
+}
+
 function returnOnlyMostSubdividedGroup(content) {
-    if (!Array.isArray(content)) {
+    let contentArray = content.toString().split(",");
+    if (contentArray.length <= 1) {
         return content;
     }
-    let lastElement = content[content.length - 1];
+    let lastElement = contentArray[contentArray.length - 1];
     return lastElement;
+}
+
+export function tickLength(standardTickLength, tickIndex, crossAxisMap) {
+    const multiplier = standardTickLength;
+
+    // ticks are shorter in the case where we're not dubdividing by groups.
+    if (crossAxisMap.length <= 1) {
+        return multiplier / 3;
+    }
+
+    let depth = 1;
+    crossAxisMap.map.forEach(level => {
+        if (level.nodeWithTick(tickIndex).ticks[0] === tickIndex) {
+            depth++;
+        }
+    });
+
+    return depth * multiplier;
 }

--- a/packages/perspective-viewer-d3fc/src/js/domStyling/groupByLayerTopography.js
+++ b/packages/perspective-viewer-d3fc/src/js/domStyling/groupByLayerTopography.js
@@ -8,12 +8,12 @@
  */
 
 import {isNullOrUndefined} from "util";
-let LABEL_TICK_PADDING = 2;
-let STANDARD_TICK_LENGTH = 9;
+const LABEL_TICK_PADDING = 2;
+const STANDARD_TICK_LENGTH = 9;
 const HORIZONTAL_STANDARD_TICK_LENGTH = -18;
 const HORIZONTAL_LABEL_TICK_PADDING = -2;
 
-export class CrossAxisMap {
+export class GroupByLayerTopography {
     constructor(crossLabels, dataset) {
         this._map = this.generateMap(crossLabels, dataset);
     }


### PR DESCRIPTION
So. This whole thing wants a redesign. The bit that works well is the core structure, with the topography comprising Levels, which in turn comprise LevelNodes, and the manner in which these are generated.

On top of this the structure, whereby label positions are calculated seems to make sense, with the caveat that the variable singleTickLength ought to be passed in to make this configurable (atm these variables are hacked in as constants). Also, owing to an oddity in the current pattern of usage, there is a line that prevents the top level of labels (IE: the most subdivided level), being considered internally here. That is a hold over from the old manner in which this was piggy backed on existing code, and should be undone for a more modular production ready iteration.

The new plan, will to be to integrate this into the existing design inside .../axis/crossAxis..js under the labelFunction. Potentially it'll mean adding the groupByLayerTopography to the settings structure we're passing around so that the rendering has access to it, because it's pretty far from pre-existing rendering of ticks and labels.

Things that would definitely want to change were we to keep the existing structure (for posterity's sake):

1. Constants for dimensions should actually be values that are passed into the groupByLayerTopography class, and down into member classes.

2. There are a couple methods that aren't actually ever used I do believe.

3. The manner in which x versus y graphs are handled ough to be refactored for clarity.