### PR TITLE
Fixed issue with toggling legend with multiple values and splitBy

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
@@ -3,7 +3,10 @@ import {getChartElement} from "../plugin/root";
 import tooltipTemplate from "../../html/tooltip.html";
 
 export function tooltip(selection, settings) {
-    const container = select(getChartElement(selection.node()).getContainer());
+    const node = selection.node();
+    if (!node) return;
+
+    const container = select(getChartElement(node).getContainer());
     const tooltipDiv = getTooltipDiv(container);
     selection
         .filter(d => d.baseValue !== d.mainValue)


### PR DESCRIPTION
The issue was actually with trying to create an empty bar series and associating a tooltip with it, which didn't check that it actually had a node to use.