### PR TITLE
Add globals and custom transformer to get unit testing working

### DIFF
--- a/packages/perspective-viewer-d3fc/jest-config.js
+++ b/packages/perspective-viewer-d3fc/jest-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    rootDir: "./",
+    transform: {
+        "^.+\\.js$": "./test/transform.js"
+    }
+};

--- a/packages/perspective-viewer-d3fc/package.json
+++ b/packages/perspective-viewer-d3fc/package.json
@@ -17,6 +17,7 @@
         "watch": "webpack --color --watch --config src/config/d3fc.plugin.config.js",
         "test:run": "jest --silent --color 2>&1",
         "test": "npm-run-all test:build test:run",
+        "test:unit": "jest --config jest-config.js",
         "clean": "find build -mindepth 1 -delete",
         "clean:screenshots": "find screenshots/ \\( -name *.diff.png -o -name *.failed.png \\) -mindepth 1 -delete"
     },
@@ -47,5 +48,15 @@
         "d3-svg-legend": "^2.25.6",
         "d3fc": "^14.0.25",
         "gradient-parser": "0.1.5"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.2.2",
+        "@babel/node": "^7.2.2",
+        "@babel/preset-env": "^7.3.1",
+        "babel-jest": "^24.1.0",
+        "babel-plugin-transform-custom-element-classes": "^0.1.0",
+        "babel-polyfill": "^6.26.0",
+        "d3": "^5.8.2",
+        "jest": "^24.1.0"
     }
 }

--- a/packages/perspective-viewer-d3fc/src/js/data/groupAndStackData.spec.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/groupAndStackData.spec.js
@@ -1,0 +1,44 @@
+import * as glob from "../globals/customElements";
+import {groupAndStackData} from "../data/groupAndStackData";
+
+glob.empty();
+
+describe("groupAndStackData should", () => {
+    test("include globals", () => {
+        expect(typeof HTMLElement).toBe("function");
+
+        expect(typeof customElements).toBe("object");
+
+        expect(typeof customElements.define).toBe("function");
+    });
+
+    test("groupAndStackData should use settings data if no specific data is supplied", () => {
+        const settings = {
+            crossValues: [{name: "cross1", type: "string"}],
+            data: [{value1: 10, __ROW_PATH__: ["CROSS1.1"]}, {value1: 20, __ROW_PATH__: ["CROSS1.2"]}, {value1: 30, __ROW_PATH__: ["CROSS1.1"]}],
+            mainValues: [{name: "value1", type: "integer"}],
+            splitValues: []
+        };
+
+        const groupedResult = groupAndStackData(settings);
+
+        expect(groupedResult[0].length).toEqual(3);
+    });
+
+    test("groupAndStackData should use specific data if supplied", () => {
+        const suppliedData = [{value1: 10, __ROW_PATH__: ["CROSS1.1"]}, {value1: 20, __ROW_PATH__: ["CROSS1.2"]}, {value1: 30, __ROW_PATH__: ["CROSS1.1"]}];
+
+        const settings = {
+            crossValues: [{name: "cross1", type: "string"}],
+            data: suppliedData,
+            mainValues: [{name: "value1", type: "integer"}],
+            splitValues: []
+        };
+
+        suppliedData.push({value1: 40, __ROW_PATH__: ["CROSS1.3"]});
+
+        const groupedResult = groupAndStackData(settings, suppliedData);
+
+        expect(groupedResult[0].length).toEqual(4);
+    });
+});

--- a/packages/perspective-viewer-d3fc/src/js/globals/customElements.js
+++ b/packages/perspective-viewer-d3fc/src/js/globals/customElements.js
@@ -1,0 +1,14 @@
+//import jsdom from "jsdom";
+global.CustomEvent = () => {};
+
+global.customElements = {define: () => {}};
+global.HTMLElement = class {
+    getAttribute() {}
+    hasAttribute() {}
+    removeAttribute() {}
+    setAttribute() {}
+};
+
+export const empty = () => {
+    // empty function that can be called to overcome the defined but never used git hook
+};

--- a/packages/perspective-viewer-d3fc/test/transform.js
+++ b/packages/perspective-viewer-d3fc/test/transform.js
@@ -1,0 +1,15 @@
+const c = require("../babel.config.js");
+
+const defaultCwd = process.cwd();
+const transformer = require("babel-jest").createTransformer(c);
+
+// Monkey patch around https://github.com/facebook/jest/issues/7868
+const oldGetCacheKey = transformer.getCacheKey;
+transformer.getCacheKey = (fileData, filename, configString, {config, instrument, rootDir}) =>
+    oldGetCacheKey(fileData, filename, configString, {
+        config: config || {cwd: defaultCwd},
+        instrument,
+        rootDir
+    });
+
+module.exports = transformer;


### PR DESCRIPTION
I managed to get it to the point where the unit tests now run.
To try it, navigate to the perspective-viewer-d3fc folder
- cd packages/perspective-viewer-d3fc
- yarn or npm install
- npm run test:unit

To get the babel to work I had to create a custom transformer (test/transform.js). This also required a workaround found here https://github.com/facebook/jest/issues/7868

For the d3fc depends on Custom Elements (v1). To avoid getting an error some global variables were required. This will need to be refactored.


