### PR TITLE
Fixed legend label not showing main value for multiple main values

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/legend/legend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/legend.js
@@ -31,12 +31,10 @@ export function legend(container, settings, colour) {
                 getChartElement(this).draw();
             });
 
-        if (settings.mainValues.length <= 1) {
-            scrollLegend.labels(options => {
-                const parts = options.domain[options.i].split("|");
-                return parts.slice(0, parts.length - 1).join("|");
-            });
-        }
+        scrollLegend.labels(options => {
+            const parts = options.domain[options.i].split("|");
+            return settings.mainValues.length <= 1 ? parts.slice(0, parts.length - 1).join("|") : options.domain[options.i];
+        });
 
         const legendSelection = getOrCreateElement(container, "div.legend-container", () => container.append("div"));
 


### PR DESCRIPTION
I don't know when this started happening but I noticed that with multiple main values, in split data, the legend wasn't displaying correctly, i.e. it didn't show which main value the label related to. This seems to fix it.

![label_before](https://user-images.githubusercontent.com/29425751/52844596-ce260200-30fc-11e9-92aa-66daba28781a.PNG) ![label_after](https://user-images.githubusercontent.com/29425751/52844603-d1b98900-30fc-11e9-9344-7fb9da5cb902.PNG)
