### PR TITLE
Implemented Area Chart

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
@@ -82,9 +82,7 @@ export const styleAxis = (chart, prefix, settings) => {
 
     switch (axisType(settings)) {
         case AXIS_TYPES.ordinal:
-            chart[`${prefix}PaddingInner`](0.5)
-                [`${prefix}PaddingOuter`](0.25)
-                [`${prefix}TickGrouping`](t => t.split("|"))
+            chart[`${prefix}TickGrouping`](t => t.split("|"))
                 [`${prefix}TickSizeInner`](settings.crossValues.length > 1 ? labelSize : 5)
                 [`${prefix}TickSizeOuter`](0)
                 [`${prefix}TickPadding`](8)

--- a/packages/perspective-viewer-d3fc/src/js/charts/area.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/area.js
@@ -11,21 +11,18 @@ import * as crossAxis from "../axis/crossAxis";
 import * as mainAxis from "../axis/mainAxis";
 import {areaSeries} from "../series/areaSeries";
 import {seriesColours} from "../series/seriesColours";
-import {groupAndStackData} from "../data/groupAndStackData";
+import {splitData} from "../data/splitData";
 import {legend, filterData} from "../legend/legend";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
 
 function areaChart(container, settings) {
-    const data = groupAndStackData(settings, filterData(settings));
+    const data = splitData(settings, filterData(settings));
     const colour = seriesColours(settings);
     legend(container, settings, colour);
 
-    const series = fc
-        .seriesSvgMulti()
-        .mapping((data, index) => data[index])
-        .series(data.map(() => areaSeries(settings, colour).orient("vertical")));
+    const series = fc.seriesSvgRepeat().series(areaSeries(settings, colour).orient("vertical"));
 
     const chart = chartSvgCartesian(crossAxis.scale(settings), mainAxis.scale(settings))
         .xDomain(crossAxis.domain(settings, data))

--- a/packages/perspective-viewer-d3fc/src/js/charts/area.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/area.js
@@ -11,14 +11,15 @@ import * as crossAxis from "../axis/crossAxis";
 import * as mainAxis from "../axis/mainAxis";
 import {areaSeries} from "../series/areaSeries";
 import {seriesColours} from "../series/seriesColours";
-import {splitData} from "../data/splitData";
+import {splitAndBaseData} from "../data/splitAndBaseData";
 import {legend, filterData} from "../legend/legend";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
 
 function areaChart(container, settings) {
-    const data = splitData(settings, filterData(settings));
+    const data = splitAndBaseData(settings, filterData(settings));
+
     const colour = seriesColours(settings);
     legend(container, settings, colour);
 

--- a/packages/perspective-viewer-d3fc/src/js/charts/area.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/area.js
@@ -9,7 +9,7 @@
 import * as fc from "d3fc";
 import * as crossAxis from "../axis/crossAxis";
 import * as mainAxis from "../axis/mainAxis";
-import {barSeries} from "../series/barSeries";
+import {areaSeries} from "../series/areaSeries";
 import {seriesColours} from "../series/seriesColours";
 import {groupAndStackData} from "../data/groupAndStackData";
 import {legend, filterData} from "../legend/legend";
@@ -17,7 +17,7 @@ import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
 
-function barChart(container, settings) {
+function areaChart(container, settings) {
     const data = groupAndStackData(settings, filterData(settings));
     const colour = seriesColours(settings);
     legend(container, settings, colour);
@@ -25,33 +25,27 @@ function barChart(container, settings) {
     const series = fc
         .seriesSvgMulti()
         .mapping((data, index) => data[index])
-        .series(
-            data.map(() =>
-                barSeries(settings, colour)
-                    .align("left")
-                    .orient("horizontal")
-            )
-        );
+        .series(data.map(() => areaSeries(settings, colour).orient("vertical")));
 
-    const chart = chartSvgCartesian(mainAxis.scale(settings), crossAxis.scale(settings))
-        .xDomain(mainAxis.domain(settings, data))
-        .yDomain(crossAxis.domain(settings, data))
+    const chart = chartSvgCartesian(crossAxis.scale(settings), mainAxis.scale(settings))
+        .xDomain(crossAxis.domain(settings, data))
+        .yDomain(mainAxis.domain(settings, data))
         .yOrient("left")
-        .plotArea(withGridLines(series).orient("horizontal"));
+        .plotArea(withGridLines(series).orient("vertical"));
 
-    crossAxis.styleAxis(chart, "y", settings);
-    mainAxis.styleAxis(chart, "x", settings);
+    crossAxis.styleAxis(chart, "x", settings);
+    mainAxis.styleAxis(chart, "y", settings);
 
-    chart.yPaddingInner && chart.yPaddingInner(0.5);
-    chart.yPaddingOuter && chart.yPaddingOuter(0.25);
+    chart.xPaddingInner && chart.xPaddingInner(1);
+    chart.xPaddingOuter && chart.xPaddingOuter(0.5);
 
     // render
     container.datum(data).call(chart);
 }
-barChart.plugin = {
-    type: "d3_x_bar",
-    name: "[d3fc] X Bar Chart",
+areaChart.plugin = {
+    type: "d3_y_area",
+    name: "[d3fc] Y Area Chart",
     max_size: 25000
 };
 
-export default barChart;
+export default areaChart;

--- a/packages/perspective-viewer-d3fc/src/js/charts/charts.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/charts.js
@@ -10,7 +10,8 @@
 import barChart from "./bar";
 import columnChart from "./column";
 import lineChart from "./line";
+import areaChart from "./area";
 import xyScatter from "./xy-scatter";
 
-const chartClasses = [barChart, columnChart, lineChart, xyScatter];
+const chartClasses = [barChart, columnChart, lineChart, areaChart, xyScatter];
 export default chartClasses;

--- a/packages/perspective-viewer-d3fc/src/js/charts/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/column.js
@@ -42,6 +42,9 @@ function columnChart(container, settings) {
     crossAxis.styleAxis(chart, "x", settings);
     mainAxis.styleAxis(chart, "y", settings);
 
+    chart.xPaddingInner && chart.xPaddingInner(0.5);
+    chart.xPaddingOuter && chart.xPaddingOuter(0.25);
+
     // render
     container.datum(data).call(chart);
 }

--- a/packages/perspective-viewer-d3fc/src/js/charts/line.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/line.js
@@ -33,8 +33,8 @@ function lineChart(container, settings) {
     crossAxis.styleAxis(chart, "x", settings);
     mainAxis.styleAxis(chart, "y", settings);
 
-    chart.xPadding && chart.xPaddingInner(1);
-    chart.xPadding && chart.xPaddingOuter(0.5);
+    chart.xPaddingInner && chart.xPaddingInner(1);
+    chart.xPaddingOuter && chart.xPaddingOuter(0.5);
 
     // render
     container.datum(data).call(chart);

--- a/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
@@ -1,0 +1,38 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {labelFunction} from "../axis/crossAxis";
+
+export function splitAndBaseData(settings, data) {
+    const labelfn = labelFunction(settings);
+
+    console.log("In splitData - data:", data);
+
+    return data.map((col, i) => {
+        const baseValues = {};
+
+        return Object.keys(col)
+            .filter(key => key !== "__ROW_PATH__")
+            .map(key => {
+                // Keys are of the form "split1|split2|aggregate"
+                const labels = key.split("|");
+                // label="aggregate"
+                const label = labels[labels.length - 1];
+                const baseValue = baseValues[label] || 0;
+                const value = baseValue + col[key];
+                baseValues[label] = value;
+
+                return {
+                    key,
+                    crossValue: labelfn(col, i),
+                    mainValue: value,
+                    baseValue: baseValue
+                };
+            });
+    });
+}

--- a/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
@@ -17,5 +17,8 @@ export function areaSeries(settings, colour) {
         }
     });
 
-    return series.crossValue(d => d.crossValue).mainValue(d => d.mainValue);
+    return series
+        .crossValue(d => d.crossValue)
+        .mainValue(d => d.mainValue)
+        .baseValue(d => d.baseValue);
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
@@ -9,7 +9,7 @@
 import * as fc from "d3fc";
 
 export function areaSeries(settings, colour) {
-    let series = settings.mainValues.length > 1 ? fc.seriesSvgGrouped(fc.seriesSvgArea()) : fc.seriesSvgArea();
+    let series = fc.seriesSvgArea();
 
     series = series.decorate(selection => {
         if (colour) {
@@ -17,8 +17,5 @@ export function areaSeries(settings, colour) {
         }
     });
 
-    return series
-        .crossValue(d => d.crossValue)
-        .mainValue(d => d.mainValue)
-        .baseValue(d => d.baseValue);
+    return series.crossValue(d => d.crossValue).mainValue(d => d.mainValue);
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
@@ -1,0 +1,24 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import * as fc from "d3fc";
+
+export function areaSeries(settings, colour) {
+    let series = settings.mainValues.length > 1 ? fc.seriesSvgGrouped(fc.seriesSvgArea()) : fc.seriesSvgArea();
+
+    series = series.decorate(selection => {
+        if (colour) {
+            selection.style("fill", d => colour(d[0].key));
+        }
+    });
+
+    return series
+        .crossValue(d => d.crossValue)
+        .mainValue(d => d.mainValue)
+        .baseValue(d => d.baseValue);
+}

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
@@ -22,14 +22,14 @@ export function pointSeries(settings, colour, seriesKey, size) {
     series.decorate(selection => {
         tooltip(selection, settings);
         if (colour) {
-            selection.style("stroke", () => colour(seriesKey)).style("fill", () => withOpacity(colour(seriesKey)));
+            selection.style("stroke", () => withOutOpacity(colour(seriesKey))).style("fill", () => colour(seriesKey));
         }
     });
 
     return series;
 }
 
-function withOpacity(colour) {
-    const toInt = offset => parseInt(colour.substring(offset, offset + 2), 16);
-    return `rgba(${toInt(1)},${toInt(3)},${toInt(5)},0.5)`;
+function withOutOpacity(colour) {
+    const lastComma = colour.lastIndexOf(",");
+    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
@@ -30,5 +30,10 @@ export function seriesColoursFromGroups(settings) {
 }
 
 function fromDomain(domain) {
-    return domain.length > 1 ? d3.scaleOrdinal(d3.schemeCategory10).domain(domain) : null;
+    return domain.length > 1 ? d3.scaleOrdinal(d3.schemeCategory10.map(withOpacity)).domain(domain) : null;
+}
+
+function withOpacity(colour) {
+    const toInt = offset => parseInt(colour.substring(offset, offset + 2), 16);
+    return `rgba(${toInt(1)},${toInt(3)},${toInt(5)},0.5)`;
 }

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -49,14 +49,17 @@
         }
 
         & .bar {
-            fill: rgb(31, 119, 180);
+            fill: rgba(31, 119, 180, 0.5);
         }
         & .line {
-            stroke: rgb(31, 119, 180);
+            stroke: rgba(194, 218, 235, 0.5);
         }
         & .point {
             fill: rgba(31, 119, 180, 0.5);
             stroke: rgb(31, 119, 180);
+        }
+        & .area {
+            fill: rgba(31, 119, 180, 0.5);
         }
     }
 


### PR DESCRIPTION
Added area chart type with areas series, using stacked multi-series data the same as for column charts
Moved `padding` out of `crossAxis`, since it was specific to bar/column charts
Area chart requires opacity for when they overlap.
Applied `opacity` as default to all chart types, since this makes the colouring consistent (and matches the legend). This actually looks more similar to Highcharts anyway.