### PR TITLE
 XY chart displays shapes as well as colour

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/area.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/area.js
@@ -12,7 +12,8 @@ import * as mainAxis from "../axis/mainAxis";
 import {areaSeries} from "../series/areaSeries";
 import {seriesColours} from "../series/seriesColours";
 import {splitAndBaseData} from "../data/splitAndBaseData";
-import {legend, filterData} from "../legend/legend";
+import {colourLegend} from "../legend/legend";
+import {filterData} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
@@ -22,7 +23,9 @@ function areaChart(container, settings) {
     const data = splitAndBaseData(settings, filterData(settings));
 
     const colour = seriesColours(settings);
-    legend(container, settings, colour);
+    const legend = colourLegend()
+        .settings(settings)
+        .scale(colour);
 
     const series = fc.seriesSvgRepeat().series(areaSeries(settings, colour).orient("vertical"));
 
@@ -46,6 +49,7 @@ function areaChart(container, settings) {
 
     // render
     container.datum(data).call(chart);
+    container.call(legend);
 }
 areaChart.plugin = {
     type: "d3_y_area",

--- a/packages/perspective-viewer-d3fc/src/js/charts/bar.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/bar.js
@@ -12,7 +12,8 @@ import * as mainAxis from "../axis/mainAxis";
 import {barSeries} from "../series/barSeries";
 import {seriesColours} from "../series/seriesColours";
 import {groupAndStackData} from "../data/groupAndStackData";
-import {legend, filterData} from "../legend/legend";
+import {colourLegend} from "../legend/legend";
+import {filterData} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
@@ -21,7 +22,10 @@ import {hardLimitZeroPadding} from "../d3fc/padding/hardLimitZero";
 function barChart(container, settings) {
     const data = groupAndStackData(settings, filterData(settings));
     const colour = seriesColours(settings);
-    legend(container, settings, colour);
+
+    const legend = colourLegend()
+        .settings(settings)
+        .scale(colour);
 
     const series = fc
         .seriesSvgMulti()
@@ -54,6 +58,7 @@ function barChart(container, settings) {
 
     // render
     container.datum(data).call(chart);
+    container.call(legend);
 }
 barChart.plugin = {
     type: "d3_x_bar",

--- a/packages/perspective-viewer-d3fc/src/js/charts/column.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/column.js
@@ -12,7 +12,8 @@ import * as mainAxis from "../axis/mainAxis";
 import {barSeries} from "../series/barSeries";
 import {seriesColours} from "../series/seriesColours";
 import {groupAndStackData} from "../data/groupAndStackData";
-import {legend, filterData} from "../legend/legend";
+import {colourLegend} from "../legend/legend";
+import {filterData} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
@@ -21,7 +22,10 @@ import {hardLimitZeroPadding} from "../d3fc/padding/hardLimitZero";
 function columnChart(container, settings) {
     const data = groupAndStackData(settings, filterData(settings));
     const colour = seriesColours(settings);
-    legend(container, settings, colour);
+
+    const legend = colourLegend()
+        .settings(settings)
+        .scale(colour);
 
     const series = fc
         .seriesSvgMulti()
@@ -54,6 +58,7 @@ function columnChart(container, settings) {
 
     // render
     container.datum(data).call(chart);
+    container.call(legend);
 }
 columnChart.plugin = {
     type: "d3_y_bar",

--- a/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/heatmap.js
@@ -12,7 +12,7 @@ import * as crossAxis from "../axis/crossAxis";
 //import * as otherAxis from "../axis/otherAxis";
 import {heatmapSeries} from "../series/heatmapSeries";
 import {heatmapData} from "../data/heatmapData";
-import {filterData} from "../legend/legend";
+import {filterData} from "../legend/filter";
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
 import {withGridLines} from "../gridlines/gridlines";
 import {legend} from "../legend/colorLegend";

--- a/packages/perspective-viewer-d3fc/src/js/charts/line.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/line.js
@@ -12,7 +12,8 @@ import * as mainAxis from "../axis/mainAxis";
 import {seriesColours} from "../series/seriesColours";
 import {lineSeries} from "../series/lineSeries";
 import {splitData} from "../data/splitData";
-import {legend, filterData} from "../legend/legend";
+import {colourLegend} from "../legend/legend";
+import {filterData} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
@@ -21,7 +22,10 @@ import {hardLimitZeroPadding} from "../d3fc/padding/hardLimitZero";
 function lineChart(container, settings) {
     const data = splitData(settings, filterData(settings));
     const colour = seriesColours(settings);
-    legend(container, settings, colour);
+
+    const legend = colourLegend()
+        .settings(settings)
+        .scale(colour);
 
     const series = fc.seriesSvgRepeat().series(lineSeries(settings, colour).orient("vertical"));
 
@@ -44,6 +48,7 @@ function lineChart(container, settings) {
 
     // render
     container.datum(data).call(chart);
+    container.call(legend);
 }
 lineChart.plugin = {
     type: "d3_y_line",

--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -8,11 +8,11 @@
  */
 import * as fc from "d3fc";
 import * as mainAxis from "../axis/mainAxis";
-import {pointSeries} from "../series/pointSeries";
+import {pointSeries, symbolTypeFromGroups} from "../series/pointSeries";
 import {pointData} from "../data/pointData";
 import {seriesColoursFromGroups} from "../series/seriesColours";
 import {seriesLinearRange} from "../series/seriesLinearRange";
-import {legend, filterDataByGroup} from "../legend/legend";
+import {symbolLegend, filterDataByGroup} from "../legend/legend";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";
@@ -20,15 +20,20 @@ import {hardLimitZeroPadding} from "../d3fc/padding/hardLimitZero";
 
 function xyScatter(container, settings) {
     const data = pointData(settings, filterDataByGroup(settings));
+    const symbols = symbolTypeFromGroups(settings);
     const colour = seriesColoursFromGroups(settings);
-    legend(container, settings, colour);
+
+    const legend = symbolLegend()
+        .settings(settings)
+        .scale(symbols)
+        .colour(colour);
 
     const size = settings.mainValues.length > 2 ? seriesLinearRange(settings, data, "size").range([10, 10000]) : null;
 
     const series = fc
         .seriesSvgMulti()
         .mapping((data, index) => data[index])
-        .series(data.map(series => pointSeries(settings, colour, series.key, size)));
+        .series(data.map(series => pointSeries(settings, series.key, size, colour, symbols)));
 
     const domainDefault = mainAxis.domain(settings).paddingStrategy(hardLimitZeroPadding().pad([0.1, 0.1]));
 
@@ -44,6 +49,7 @@ function xyScatter(container, settings) {
 
     // render
     container.datum(data).call(chart);
+    container.call(legend);
 }
 xyScatter.plugin = {
     type: "d3_xy_scatter",

--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -12,7 +12,8 @@ import {pointSeries, symbolTypeFromGroups} from "../series/pointSeries";
 import {pointData} from "../data/pointData";
 import {seriesColoursFromGroups} from "../series/seriesColours";
 import {seriesLinearRange} from "../series/seriesLinearRange";
-import {symbolLegend, filterDataByGroup} from "../legend/legend";
+import {symbolLegend} from "../legend/legend";
+import {filterDataByGroup} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 
 import chartSvgCartesian from "../d3fc/chart/svg/cartesian";

--- a/packages/perspective-viewer-d3fc/src/js/legend/filter.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/filter.js
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {groupFromKey} from "../series/seriesKey";
+
+export function filterData(settings, data) {
+    const useData = data || settings.data;
+    if (settings.hideKeys && settings.hideKeys.length > 0) {
+        return useData.map(col => {
+            const clone = {...col};
+            settings.hideKeys.forEach(k => {
+                delete clone[k];
+            });
+            return clone;
+        });
+    }
+    return useData;
+}
+
+export function filterDataByGroup(settings, data) {
+    const useData = data || settings.data;
+    if (settings.hideKeys && settings.hideKeys.length > 0) {
+        return useData.map(col => {
+            const clone = {};
+            Object.keys(col).map(key => {
+                if (!settings.hideKeys.includes(groupFromKey(key))) {
+                    clone[key] = col[key];
+                }
+            });
+            return clone;
+        });
+    }
+    return useData;
+}

--- a/packages/perspective-viewer-d3fc/src/js/legend/legend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/legend.js
@@ -7,47 +7,125 @@
  *
  */
 
+import * as d3 from "d3";
+import * as d3Legend from "d3-svg-legend";
 import scrollableLegend from "./scrollableLegend";
 import {getChartElement} from "../plugin/root";
 import {groupFromKey} from "../series/seriesKey";
 import {getOrCreateElement} from "../utils/utils";
 
-const scrollLegend = scrollableLegend();
-export function legend(container, settings, colour) {
-    if (colour) {
-        scrollLegend
-            .scale(colour)
-            .shape("circle")
-            .shapeRadius(6)
-            .orient("vertical")
-            .on("cellclick", function(d) {
-                settings.hideKeys = settings.hideKeys || [];
-                if (settings.hideKeys.includes(d)) {
-                    settings.hideKeys = settings.hideKeys.filter(k => k !== d);
-                } else {
-                    settings.hideKeys.push(d);
-                }
+const scrollColourLegend = scrollableLegend(
+    d3Legend
+        .legendColor()
+        .shape("circle")
+        .shapeRadius(6)
+);
+const scrollSymbolLegend = scrollableLegend(
+    d3Legend
+        .legendSymbol()
+        .shapePadding(1)
+        .labelOffset(3)
+);
 
-                getChartElement(this).draw();
+export function legend(container, settings, colour) {
+    container.call(
+        legendComponent(scrollColourLegend)
+            .settings(settings)
+            .scale(colour)
+    );
+}
+export const symbolLegend = () => legendComponent(scrollSymbolLegend, symbolScale);
+
+function symbolScale(fromScale) {
+    if (!fromScale) return null;
+
+    const domain = fromScale.domain();
+    const range = fromScale.range().map(r => d3.symbol().type(r)());
+    return d3
+        .scaleOrdinal()
+        .domain(domain)
+        .range(range);
+}
+
+function legendComponent(scrollLegend, scaleModifier) {
+    let settings = {};
+    let scale = null;
+    let colour = null;
+
+    function legend(container) {
+        if (scale) {
+            scrollLegend
+                .scale(scale)
+                .orient("vertical")
+                .on("cellclick", function(d) {
+                    settings.hideKeys = settings.hideKeys || [];
+                    if (settings.hideKeys.includes(d)) {
+                        settings.hideKeys = settings.hideKeys.filter(k => k !== d);
+                    } else {
+                        settings.hideKeys.push(d);
+                    }
+
+                    getChartElement(this).draw();
+                });
+
+            scrollLegend.labels(options => {
+                const parts = options.domain[options.i].split("|");
+                return settings.mainValues.length <= 1 ? parts.slice(0, parts.length - 1).join("|") : options.domain[options.i];
             });
 
-        scrollLegend.labels(options => {
-            const parts = options.domain[options.i].split("|");
-            return settings.mainValues.length <= 1 ? parts.slice(0, parts.length - 1).join("|") : options.domain[options.i];
-        });
+            const legendSelection = getOrCreateElement(container, "div.legend-container", () => container.append("div"));
 
-        const legendSelection = getOrCreateElement(container, "div.legend-container", () => container.append("div"));
+            // render the legend
+            legendSelection
+                .attr("class", "legend-container")
+                .style("z-index", "2")
+                .call(scrollLegend);
+        }
+    }
 
-        // render the legend
-        legendSelection
-            .attr("class", "legend-container")
-            .style("z-index", "2")
-            .call(scrollLegend)
+    scrollLegend.decorate(selection => {
+        const isHidden = data => settings.hideKeys && settings.hideKeys.includes(data);
+
+        const cells = selection
             .select("g.legendCells")
             .attr("transform", "translate(20,20)")
-            .selectAll("g.cell")
-            .classed("hidden", data => settings.hideKeys && settings.hideKeys.includes(data));
-    }
+            .selectAll("g.cell");
+
+        cells.classed("hidden", isHidden);
+
+        if (colour) {
+            cells
+                .select("path")
+                .style("fill", d => (isHidden(d) ? null : colour(d)))
+                .style("stroke", d => (isHidden(d) ? null : withOutOpacity(colour(d))));
+        }
+    });
+
+    legend.settings = (...args) => {
+        if (!args.length) {
+            return settings;
+        }
+        settings = args[0];
+        return legend;
+    };
+
+    legend.scale = (...args) => {
+        if (!args.length) {
+            return scale;
+        }
+        scale = scaleModifier ? scaleModifier(args[0]) : args[0];
+        return legend;
+    };
+
+    legend.colour = (...args) => {
+        if (!args.length) {
+            return colour;
+        }
+        colour = args[0];
+        return legend;
+    };
+
+    return legend;
 }
 
 export function filterData(settings, data) {
@@ -78,4 +156,9 @@ export function filterDataByGroup(settings, data) {
         });
     }
     return useData;
+}
+
+function withOutOpacity(colour) {
+    const lastComma = colour.lastIndexOf(",");
+    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
 }

--- a/packages/perspective-viewer-d3fc/src/js/legend/legend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/legend.js
@@ -10,8 +10,8 @@
 import * as d3 from "d3";
 import * as d3Legend from "d3-svg-legend";
 import scrollableLegend from "./scrollableLegend";
+import {withoutOpacity} from "../series/seriesColours";
 import {getChartElement} from "../plugin/root";
-import {groupFromKey} from "../series/seriesKey";
 import {getOrCreateElement} from "../utils/utils";
 
 const scrollColourLegend = scrollableLegend(
@@ -27,13 +27,7 @@ const scrollSymbolLegend = scrollableLegend(
         .labelOffset(3)
 );
 
-export function legend(container, settings, colour) {
-    container.call(
-        legendComponent(scrollColourLegend)
-            .settings(settings)
-            .scale(colour)
-    );
-}
+export const colourLegend = () => legendComponent(scrollColourLegend);
 export const symbolLegend = () => legendComponent(scrollSymbolLegend, symbolScale);
 
 function symbolScale(fromScale) {
@@ -97,7 +91,7 @@ function legendComponent(scrollLegend, scaleModifier) {
             cells
                 .select("path")
                 .style("fill", d => (isHidden(d) ? null : colour(d)))
-                .style("stroke", d => (isHidden(d) ? null : withOutOpacity(colour(d))));
+                .style("stroke", d => (isHidden(d) ? null : withoutOpacity(colour(d))));
         }
     });
 
@@ -126,39 +120,4 @@ function legendComponent(scrollLegend, scaleModifier) {
     };
 
     return legend;
-}
-
-export function filterData(settings, data) {
-    const useData = data || settings.data;
-    if (settings.hideKeys && settings.hideKeys.length > 0) {
-        return useData.map(col => {
-            const clone = {...col};
-            settings.hideKeys.forEach(k => {
-                delete clone[k];
-            });
-            return clone;
-        });
-    }
-    return useData;
-}
-
-export function filterDataByGroup(settings, data) {
-    const useData = data || settings.data;
-    if (settings.hideKeys && settings.hideKeys.length > 0) {
-        return useData.map(col => {
-            const clone = {};
-            Object.keys(col).map(key => {
-                if (!settings.hideKeys.includes(groupFromKey(key))) {
-                    clone[key] = col[key];
-                }
-            });
-            return clone;
-        });
-    }
-    return useData;
-}
-
-function withOutOpacity(colour) {
-    const lastComma = colour.lastIndexOf(",");
-    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
 }

--- a/packages/perspective-viewer-d3fc/src/js/legend/scrollableLegend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/scrollableLegend.js
@@ -11,12 +11,13 @@ import {rebindAll} from "d3fc";
 import {areArraysEqualSimple, getOrCreateElement} from "../utils/utils";
 import legendControlsTemplate from "../../html/legend-controls.html";
 
-export default () => {
-    const legend = d3Legend.legendColor();
+export default fromLegend => {
+    const legend = fromLegend || d3Legend.legendColor();
     let domain = [];
     let pageCount = 1;
     let pageSize = 15;
     let pageIndex = 0;
+    let decorate = () => {};
 
     const scrollableLegend = selection => {
         const newDomain = legend.scale().domain();
@@ -63,6 +64,8 @@ export default () => {
 
     const renderLegend = selection => {
         if (pageCount > 1) legend.cellFilter(cellFilter());
+        selection.select("g.legendCells").remove();
+
         const legendElement = getLegendElement(selection);
         legendElement.call(legend);
 
@@ -71,6 +74,8 @@ export default () => {
             .node()
             .getBBox();
         legendElement.attr("height", cellSize.height + 20);
+
+        decorate(selection);
     };
 
     const cellFilter = () => {
@@ -86,6 +91,14 @@ export default () => {
         );
 
     const getLegendElement = container => getOrCreateElement(container, ".legend", () => container.append("svg").attr("class", "legend"));
+
+    scrollableLegend.decorate = (...args) => {
+        if (!args.length) {
+            return decorate;
+        }
+        decorate = args[0];
+        return scrollableLegend;
+    };
 
     rebindAll(scrollableLegend, legend);
     return scrollableLegend;

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
@@ -9,7 +9,8 @@
 import * as d3 from "d3";
 import * as fc from "d3fc";
 import {tooltip} from "../tooltip/tooltip";
-import {groupFromKey} from "../series/seriesKey";
+import {groupFromKey} from "./seriesKey";
+import {withoutOpacity} from "./seriesColours";
 
 const symbols = [d3.symbolCircle, d3.symbolCross, d3.symbolDiamond, d3.symbolSquare, d3.symbolStar, d3.symbolTriangle, d3.symbolWye];
 
@@ -29,16 +30,11 @@ export function pointSeries(settings, seriesKey, size, colour, symbols) {
     series.decorate(selection => {
         tooltip()(selection, settings);
         if (colour) {
-            selection.style("stroke", () => withOutOpacity(colour(seriesKey))).style("fill", () => colour(seriesKey));
+            selection.style("stroke", () => withoutOpacity(colour(seriesKey))).style("fill", () => colour(seriesKey));
         }
     });
 
     return series;
-}
-
-function withOutOpacity(colour) {
-    const lastComma = colour.lastIndexOf(",");
-    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
 }
 
 export function symbolTypeFromGroups(settings) {

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeries.js
@@ -6,10 +6,14 @@
  * the Apache License 2.0.  The full license can be found in the LICENSE file.
  *
  */
+import * as d3 from "d3";
 import * as fc from "d3fc";
 import {tooltip} from "../tooltip/tooltip";
+import {groupFromKey} from "../series/seriesKey";
 
-export function pointSeries(settings, colour, seriesKey, size) {
+const symbols = [d3.symbolCircle, d3.symbolCross, d3.symbolDiamond, d3.symbolSquare, d3.symbolStar, d3.symbolTriangle, d3.symbolWye];
+
+export function pointSeries(settings, seriesKey, size, colour, symbols) {
     let series = fc
         .seriesSvgPoint()
         .crossValue(d => d.x)
@@ -17,6 +21,9 @@ export function pointSeries(settings, colour, seriesKey, size) {
 
     if (size) {
         series.size(d => size(d.size));
+    }
+    if (symbols) {
+        series.type(symbols(seriesKey));
     }
 
     series.decorate(selection => {
@@ -32,4 +39,27 @@ export function pointSeries(settings, colour, seriesKey, size) {
 function withOutOpacity(colour) {
     const lastComma = colour.lastIndexOf(",");
     return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
+}
+
+export function symbolTypeFromGroups(settings) {
+    const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
+    const domain = [];
+    Object.keys(col).forEach(key => {
+        if (key !== "__ROW_PATH__") {
+            const group = groupFromKey(key);
+            if (!domain.includes(group)) {
+                domain.push(group);
+            }
+        }
+    });
+    return fromDomain(domain);
+}
+
+function fromDomain(domain) {
+    return domain.length > 1
+        ? d3
+              .scaleOrdinal()
+              .domain(domain)
+              .range(symbols)
+        : null;
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
@@ -33,7 +33,12 @@ function fromDomain(domain) {
     return domain.length > 1 ? d3.scaleOrdinal(d3.schemeCategory10.map(withOpacity)).domain(domain) : null;
 }
 
-function withOpacity(colour) {
+export function withoutOpacity(colour) {
+    const lastComma = colour.lastIndexOf(",");
+    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
+}
+
+export function withOpacity(colour) {
     const toInt = offset => parseInt(colour.substring(offset, offset + 2), 16);
     return `rgba(${toInt(1)},${toInt(3)},${toInt(5)},0.5)`;
 }

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -80,6 +80,15 @@
             & .cell {
                 cursor: pointer;
 
+                & path {
+                    fill: rgba(31, 119, 180, 0.5);
+                    stroke: rgb(31, 119, 180);
+                }
+                &.hidden  path {
+                    fill: rgba(204, 204, 204, 0.5);
+                    stroke: rgb(204, 204, 204);
+                }
+
                 &.hidden circle {
                     fill: rgb(204, 204, 204) !important;
                 }


### PR DESCRIPTION
Shape also has to be displayed in the legend

Make legend more d3 component-like 

2 types of legend - colour (categories) and symbol (shape and colour)

Moved filter functions to their own module

Note: I have left the colour-range legend component as it is, since Ronan is working on it, but it would be good to re-write that as a d3-like component too.