### PR TITLE
in area chart console no longer logs and y axis line hidden using css

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
@@ -11,8 +11,6 @@ import {labelFunction} from "../axis/crossAxis";
 export function splitAndBaseData(settings, data) {
     const labelfn = labelFunction(settings);
 
-    console.log("In splitData - data:", data);
-
     return data.map((col, i) => {
         const baseValues = {};
 

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -38,6 +38,7 @@
 
         &.d3_y_bar .y-axis path,
         &.d3_y_line .y-axis path,
+        &.d3_y_area .y-axis path,
         &.d3_xy_scatter .y-axis path,
         &.d3_xy_scatter .x-axis path,
         &.d3_x_bar .x-axis path {


### PR DESCRIPTION
Super minor fixes. But I didn't want to shoehorn them into some unrelated feature branch, so here they are.