### PR TITLE
Basic mouse-wheel zooming for continuous scales

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/zoom/zoomableChart.js
+++ b/packages/perspective-viewer-d3fc/src/js/zoom/zoomableChart.js
@@ -33,8 +33,10 @@ export default () => {
                 applyTransform(transform);
                 selection.call(chart);
 
+                const noZoom = transform.k === 1 && transform.x === 0 && transform.y === 0;
+
                 getZoomControls(selection)
-                    .style("display", transform.k === 1 ? "none" : "")
+                    .style("display", noZoom ? "none" : "")
                     .select("#zoom-reset")
                     .on("click", () => {
                         selection.select(".plot-area").call(zoom.transform, d3.zoomIdentity);


### PR DESCRIPTION
Implemented basic mouse-wheel based scrolling (with a "Reset zoom" button) for all chart types, but currently limited to continuous scales (i.e. XY chart and only time series x-axis for other charts).

For column/bar/line etc the zoom only applies to a single axis as appropriate.

Hopefully we'll be able to add a drag-area based zoom that can be applied to ordinal scales (restricting the domain to the selected columns etc).