### PR TITLE
remove duplicate withOutOpacity method from seriesColours

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/series/lineSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/lineSeries.js
@@ -7,14 +7,14 @@
  *
  */
 import * as fc from "d3fc";
-import {withOutOpacity} from "./seriesColours.js";
+import {withoutOpacity} from "./seriesColours.js";
 
 export function lineSeries(settings, colour) {
     let series = fc.seriesSvgLine();
 
     if (colour) {
         series = series.decorate(selection => {
-            selection.style("stroke", d => withOutOpacity(colour(d[0] && d[0].key)));
+            selection.style("stroke", d => withoutOpacity(colour(d[0] && d[0].key)));
         });
     }
 

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
@@ -44,8 +44,3 @@ export function withOpacity(colour) {
     const toInt = offset => parseInt(colour.substring(offset, offset + 2), 16);
     return `rgba(${toInt(1)},${toInt(3)},${toInt(5)},0.5)`;
 }
-
-export function withOutOpacity(colour) {
-    const lastComma = colour.lastIndexOf(",");
-    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
-}


### PR DESCRIPTION
Removed the additional duplicate withOutOpacity method from seriesColours and updated imports to use withoutOpacity 