### PR TITLE
Fixed some MS-Edge issues

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
+++ b/packages/perspective-viewer-d3fc/src/js/axis/crossAxis.js
@@ -35,6 +35,14 @@ export const scale = (settings, settingName = "crossValues") => {
 
 const defaultScaleBand = () => minBandwidth(d3.scaleBand());
 
+const flattenArray = array => {
+    if (Array.isArray(array)) {
+        return [].concat(...array.map(flattenArray));
+    } else {
+        return [array];
+    }
+};
+
 export const domain = settings => {
     let valueName = "crossValue";
     let settingName = "crossValues";
@@ -42,7 +50,7 @@ export const domain = settings => {
     const extentTime = fc.extentTime().accessors([d => new Date(d[valueName])]);
 
     const _domain = function(data) {
-        const flattenedData = data.flat(2);
+        const flattenedData = flattenArray(data);
         switch (axisType(settings, settingName)) {
             case AXIS_TYPES.time:
                 return extentTime(flattenedData);

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -37,6 +37,12 @@ class D3FCChartElement extends HTMLElement {
         this._chart = chart;
         this._settings = this._configureSettings(this._settings, settings);
         this.draw();
+
+        if (window.navigator.userAgent.indexOf("Edge") > -1) {
+            // Workaround for MS Edge issue that doesn't draw content in the
+            // plot-area until the chart D3 object is redrawn
+            setTimeout(() => this.draw());
+        }
     }
 
     draw() {

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColours.js
@@ -35,11 +35,12 @@ function fromDomain(domain) {
 
 export function withoutOpacity(colour) {
     const lastComma = colour.lastIndexOf(",");
-    return lastComma !== -1 ? `${colour.substring(0, lastComma)})` : colour;
+    const valueIndex = colour.indexOf("(");
+    return valueIndex !== -1 && lastComma !== -1 ? `rgb(${colour.substring(valueIndex + 1, lastComma)})` : colour;
 }
 
 export function withOpacity(colour) {
-    if (colour.includes("rgba")) return colour;
+    if (colour.includes("rgb")) return colour;
 
     const toInt = offset => parseInt(colour.substring(offset, offset + 2), 16);
     return `rgba(${toInt(1)},${toInt(3)},${toInt(5)},0.5)`;


### PR DESCRIPTION
Replaced use of Array.flat
"Fixed" `withoutOpacity` function so that it uses "rgb()" instead of "rgba()"
Added workaround for weird Edge issue that doesn't render the plot-area of some charts (bar/column charts and heatmap) unless you resize the window. An immediate redraw of the D3 element seems to work, but is not great.