### PR TITLE
Improved and simplified nearby-tooltip code and used on y-scatter

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/area.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/area.js
@@ -66,16 +66,15 @@ function areaChart(container, settings) {
         .xScale(xScale);
 
     const toolTip = nearbyTip()
-        .chart(chart)
         .settings(settings)
         .xScale(xScale)
         .yScale(yScale)
         .color(color)
         .data(data);
-    container.call(toolTip);
 
     // render
     container.datum(data).call(zoomChart);
+    container.call(toolTip);
     container.call(legend);
 }
 areaChart.plugin = {

--- a/packages/perspective-viewer-d3fc/src/js/charts/line.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/line.js
@@ -64,16 +64,15 @@ function lineChart(container, settings) {
         .xScale(xScale);
 
     const toolTip = nearbyTip()
-        .chart(chart)
         .settings(settings)
         .xScale(xScale)
         .yScale(yScale)
         .color(color)
         .data(data);
-    container.call(toolTip);
 
     // render
     container.datum(data).call(zoomChart);
+    container.call(toolTip);
     container.call(legend);
 }
 

--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -70,7 +70,6 @@ function xyScatter(container, settings) {
         .canvas(true);
 
     const toolTip = nearbyTip()
-        .chart(chart)
         .settings(settings)
         .canvas(true)
         .xScale(xScale)
@@ -78,11 +77,12 @@ function xyScatter(container, settings) {
         .yValueName("y")
         .yScale(yScale)
         .color(useGroupColors && color)
+        .size(size)
         .data(data);
-    container.call(toolTip);
 
     // render
     container.datum(data).call(zoomChart);
+    container.call(toolTip);
     if (legend) container.call(legend);
 }
 xyScatter.plugin = {

--- a/packages/perspective-viewer-d3fc/src/js/charts/y-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/y-scatter.js
@@ -17,6 +17,7 @@ import {filterData} from "../legend/filter";
 import {withGridLines} from "../gridlines/gridlines";
 import {hardLimitZeroPadding} from "../d3fc/padding/hardLimitZero";
 import zoomableChart from "../zoom/zoomableChart";
+import nearbyTip from "../tooltip/nearbyTip";
 
 function yScatter(container, settings) {
     const data = groupData(settings, filterData(settings));
@@ -40,11 +41,12 @@ function yScatter(container, settings) {
     const xDomain = crossAxis.domain(settings)(data);
     const xScale = crossAxis.scale(settings);
     const xAxis = crossAxis.axisFactory(settings).domain(xDomain)();
+    const yScale = mainAxis.scale(settings);
 
     const chart = fc
         .chartSvgCartesian({
             xScale,
-            yScale: mainAxis.scale(settings),
+            yScale,
             xAxis
         })
         .xDomain(xDomain)
@@ -65,8 +67,16 @@ function yScatter(container, settings) {
         .settings(settings)
         .xScale(xScale);
 
+    const toolTip = nearbyTip()
+        .settings(settings)
+        .xScale(xScale)
+        .yScale(yScale)
+        .color(color)
+        .data(data);
+
     // render
     container.datum(data).call(zoomChart);
+    container.call(toolTip);
     if (legend) {
         container.call(legend);
     }

--- a/packages/perspective-viewer-d3fc/src/js/series/barSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/barSeries.js
@@ -13,7 +13,7 @@ export function barSeries(settings, color) {
     let series = settings.mainValues.length > 1 ? fc.seriesSvgGrouped(fc.seriesSvgBar()) : fc.seriesSvgBar();
 
     series = series.decorate(selection => {
-        tooltip()(selection, settings);
+        tooltip().settings(settings)(selection);
         if (color) {
             selection.style("fill", d => color(d.key));
         }

--- a/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
@@ -7,7 +7,6 @@
  *
  */
 import * as fc from "d3fc";
-import {tooltip} from "../tooltip/tooltip";
 import {withOpacity, withoutOpacity} from "./seriesColors";
 import {fromDomain} from "./seriesSymbols";
 
@@ -19,7 +18,6 @@ export function categoryPointSeries(settings, seriesKey, color, symbols) {
     }
 
     series.decorate(selection => {
-        tooltip()(selection, settings);
         if (color) {
             selection.style("stroke", d => withoutOpacity(color(d.colorValue || seriesKey))).style("fill", d => withOpacity(color(d.colorValue || seriesKey)));
         }

--- a/packages/perspective-viewer-d3fc/src/js/series/heatmapSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/heatmapSeries.js
@@ -14,7 +14,9 @@ export function heatmapSeries(settings, color) {
     let series = fc.seriesSvgHeatmap();
 
     series.decorate(selection => {
-        tooltip().generateHtml(generateHtmlForHeatmap)(selection, settings);
+        tooltip()
+            .generateHtml(generateHtmlForHeatmap)
+            .settings(settings)(selection);
     });
 
     return fc

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
@@ -8,8 +8,9 @@ export const tooltip = () => {
     let generateHtml = generateHtmlDefault;
     let alwaysShow = false;
     let tooltipDiv = null;
+    let settings = null;
 
-    const _tooltip = (selection, settings) => {
+    const _tooltip = selection => {
         const node = selection.node();
 
         if (!node || !node.isConnected) {
@@ -53,6 +54,14 @@ export const tooltip = () => {
             return alwaysShow;
         }
         alwaysShow = args[0];
+        return _tooltip;
+    };
+
+    _tooltip.settings = (...args) => {
+        if (!args.length) {
+            return settings;
+        }
+        settings = args[0];
         return _tooltip;
     };
 

--- a/packages/perspective-viewer-d3fc/src/js/utils/utils.js
+++ b/packages/perspective-viewer-d3fc/src/js/utils/utils.js
@@ -15,11 +15,3 @@ export function getOrCreateElement(container, selector, createCallback) {
     let element = container.select(selector);
     return element.size() > 0 ? element : createCallback();
 }
-
-export const chainCallback = (property, fn) => {
-    const oldFn = property();
-    property((...args) => {
-        if (oldFn) oldFn(...args);
-        fn(...args);
-    });
-};

--- a/packages/perspective-viewer-d3fc/src/js/zoom/zoomableChart.js
+++ b/packages/perspective-viewer-d3fc/src/js/zoom/zoomableChart.js
@@ -10,7 +10,6 @@
 import * as d3 from "d3";
 import {getOrCreateElement} from "../utils/utils";
 import template from "../../html/zoom-controls.html";
-import {chainCallback} from "../utils/utils";
 
 export default () => {
     let chart = null;
@@ -46,7 +45,7 @@ export default () => {
                     });
             });
 
-            chainCallback(chart.decorate, sel => {
+            chart.decorate(sel => {
                 if (!bound) {
                     bound = true;
                     // add the zoom interaction on the enter selection


### PR DESCRIPTION
It turns out we don't actually need to use copies of the scales, and therefore can avoid decorating the chart object to get the "measure" (though this approach does require calling the "toolTip" component after the chart has been rendered). By the time the pointer events happen, the scales already have the correct ranges, and we need to handle the scales changing with zoom. The old code wasn't actually using the copies anyway! This change allows us to simplify the code quite a lot.

Also:
* rebind `settings` and other properties from base tooltip component
* added `size` option for controlling highlight sizing (though the "range" has to be modified because the symbol size behaviour isn't the same as the circle radius behaviour)
* Use nearby-tooltip for the y-scatter chart, since it's a better experience