### PR TITLE
Implemented selection events from d3fc plugin

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/data/groupData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/groupData.js
@@ -35,7 +35,8 @@ function seriesDataFn(settings, data, {stack = false}) {
             crossValue: labelfn(col, i),
             mainValue: !!col[mainValue.name] ? col[mainValue.name] : null,
             baseValue: baseValue(col),
-            key: col.__KEY__ ? `${col.__KEY__}|${mainValue.name}` : mainValue.name
+            key: col.__KEY__ ? `${col.__KEY__}|${mainValue.name}` : mainValue.name,
+            row: col.row || col
         }));
         series.key = series[0].key;
         return series;

--- a/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/heatmapData.js
@@ -21,7 +21,8 @@ export function heatmapData(settings, data) {
                 heatmapData.push({
                     crossValue: crossValue,
                     mainValue: getMainValues(key),
-                    colorValue: col[key]
+                    colorValue: col[key],
+                    row: col
                 });
             });
     });

--- a/packages/perspective-viewer-d3fc/src/js/data/ohlcData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/ohlcData.js
@@ -27,7 +27,8 @@ function seriesToOHLC(settings, data) {
             closeValue: closeValue,
             highValue: settings.mainValues.length >= 3 ? col[settings.mainValues[2].name] : Math.max(openValue, closeValue),
             lowValue: settings.mainValues.length >= 4 ? col[settings.mainValues[3].name] : Math.min(openValue, closeValue),
-            key: data.key
+            key: data.key,
+            row: col
         };
     });
 

--- a/packages/perspective-viewer-d3fc/src/js/data/pointData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/pointData.js
@@ -23,7 +23,8 @@ function seriesToPoints(settings, data) {
         y: col[settings.mainValues[1].name],
         colorValue: settings.mainValues.length > 2 ? col[settings.mainValues[2].name] : undefined,
         size: settings.mainValues.length > 3 ? col[settings.mainValues[3].name] : undefined,
-        key: data.key
+        key: data.key,
+        row: col
     }));
 
     mappedSeries.key = data.key;

--- a/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/splitAndBaseData.js
@@ -29,7 +29,8 @@ export function splitAndBaseData(settings, data) {
                     key,
                     crossValue: labelfn(col, i),
                     mainValue: value,
-                    baseValue: baseValue
+                    baseValue: baseValue,
+                    row: col
                 };
             });
     });

--- a/packages/perspective-viewer-d3fc/src/js/data/splitData.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/splitData.js
@@ -17,7 +17,8 @@ export function splitData(settings, data) {
             .map(key => ({
                 key,
                 crossValue: labelfn(col, i),
-                mainValue: col[key]
+                mainValue: col[key],
+                row: col
             }));
     });
 }

--- a/packages/perspective-viewer-d3fc/src/js/data/splitIntoMultiSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/data/splitIntoMultiSeries.js
@@ -53,6 +53,7 @@ function splitByValuesIntoMultiSeries(settings, data, {stack = false, excludeEmp
                 } else {
                     splitValues[label] = value;
                 }
+                splitValues.row = col;
             });
 
         // Push each object onto the correct series

--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -37,6 +37,7 @@ function drawChart(chart) {
         const col_pivots = this._get_view_column_pivots();
         const aggregates = this._get_view_aggregates();
         const hidden = this._get_view_hidden(aggregates);
+        const filter = this._view._config.filter;
 
         const [tschema, json] = await Promise.all([this._table.schema(), view.to_json()]);
         if (task.cancelled) {
@@ -50,6 +51,7 @@ function drawChart(chart) {
             crossValues: row_pivots.map(r => ({name: r, type: tschema[r]})),
             mainValues: aggregates.map(a => ({name: a.column, type: tschema[a.column]})),
             splitValues: col_pivots.map(r => ({name: r, type: tschema[r]})),
+            filter,
             data: filtered.map(dataMap)
         };
 

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/generateHTML.js
@@ -7,40 +7,13 @@
  *
  */
 import {select} from "d3";
+import {getGroupValues, getSplitValues, getDataValues} from "./selectionData";
 
 export function generateHtml(tooltipDiv, data, settings) {
     const tooltipValues = getGroupValues(data, settings)
         .concat(getSplitValues(data, settings))
         .concat(getDataValues(data, settings));
     addDataValues(tooltipDiv, tooltipValues);
-}
-
-function getGroupValues(data, settings) {
-    if (settings.crossValues.length === 0) return [];
-    const groupValues = (data.crossValue.split ? data.crossValue.split("|") : [data.crossValue]) || [data.key];
-    return settings.crossValues.map((cross, i) => ({name: cross.name, value: groupValues[i]}));
-}
-
-function getSplitValues(data, settings) {
-    if (settings.splitValues.length === 0) return [];
-    const splitValues = data.key ? data.key.split("|") : data.mainValue.split("|");
-    return settings.splitValues.map((split, i) => ({name: split.name, value: splitValues[i]}));
-}
-
-function getDataValues(data, settings) {
-    if (settings.mainValues.length > 1) {
-        if (data.mainValue) {
-            return {
-                name: data.key,
-                value: data.mainValue
-            };
-        }
-        return settings.mainValues.map((main, i) => ({name: main.name, value: data.mainValues[i]}));
-    }
-    return {
-        name: settings.mainValues[0].name,
-        value: data.colorValue || data.mainValue - data.baseValue || data.mainValue
-    };
 }
 
 function addDataValues(tooltipDiv, values) {

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/nearbyTip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/nearbyTip.js
@@ -11,6 +11,7 @@ import * as fc from "d3fc";
 import {tooltip} from "./tooltip";
 import {withOpacity} from "../series/seriesColors.js";
 import {findBestFromData} from "../data/findBest";
+import {raiseEvent} from "./selectionEvent";
 
 export default () => {
     const base = tooltip().alwaysShow(true);
@@ -27,8 +28,9 @@ export default () => {
     function nearbyTip(selection) {
         const chartPlotArea = `d3fc-${canvas ? "canvas" : "svg"}.plot-area`;
         if (xScale || yScale) {
+            let tooltipData = null;
             const pointer = fc.pointer().on("point", event => {
-                const tooltipData = event.length ? [getClosestDataPoint(event[0])] : [];
+                tooltipData = event.length ? [getClosestDataPoint(event[0])] : [];
 
                 renderTip(selection, tooltipData);
             });
@@ -36,6 +38,11 @@ export default () => {
             selection
                 .select(chartPlotArea)
                 .on("measure.nearbyTip", () => renderTip(selection, []))
+                .on("click", () => {
+                    if (tooltipData.length) {
+                        raiseEvent(selection.node(), tooltipData[0], base.settings());
+                    }
+                })
                 .call(pointer);
         }
     }

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+export function getGroupValues(data, settings) {
+    if (settings.crossValues.length === 0) return [];
+    const groupValues = (data.crossValue.split ? data.crossValue.split("|") : [data.crossValue]) || [data.key];
+    return settings.crossValues.map((cross, i) => ({name: cross.name, value: groupValues[i]}));
+}
+
+export function getSplitValues(data, settings) {
+    if (settings.splitValues.length === 0) return [];
+    const splitValues = data.key ? data.key.split("|") : data.mainValue.split("|");
+    return settings.splitValues.map((split, i) => ({name: split.name, value: splitValues[i]}));
+}
+
+export function getDataValues(data, settings) {
+    if (settings.mainValues.length > 1) {
+        if (data.mainValue) {
+            return [
+                {
+                    name: data.key,
+                    value: data.mainValue
+                }
+            ];
+        }
+        return settings.mainValues.map((main, i) => ({name: main.name, value: data.mainValues[i]}));
+    }
+    return [
+        {
+            name: settings.mainValues[0].name,
+            value: data.colorValue || data.mainValue - data.baseValue || data.mainValue
+        }
+    ];
+}

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionData.js
@@ -7,16 +7,28 @@
  *
  */
 
+function toValue(type, value) {
+    switch (type) {
+        case "datetime":
+            return value instanceof Date ? value : new Date(parseInt(value));
+        case "integer":
+            return parseInt(value, 10);
+        case "float":
+            return parseFloat(value);
+    }
+    return value;
+}
+
 export function getGroupValues(data, settings) {
     if (settings.crossValues.length === 0) return [];
     const groupValues = (data.crossValue.split ? data.crossValue.split("|") : [data.crossValue]) || [data.key];
-    return settings.crossValues.map((cross, i) => ({name: cross.name, value: groupValues[i]}));
+    return settings.crossValues.map((cross, i) => ({name: cross.name, value: toValue(cross.type, groupValues[i])}));
 }
 
 export function getSplitValues(data, settings) {
     if (settings.splitValues.length === 0) return [];
     const splitValues = data.key ? data.key.split("|") : data.mainValue.split("|");
-    return settings.splitValues.map((split, i) => ({name: split.name, value: splitValues[i]}));
+    return settings.splitValues.map((split, i) => ({name: split.name, value: toValue(split.type, splitValues[i])}));
 }
 
 export function getDataValues(data, settings) {
@@ -29,7 +41,7 @@ export function getDataValues(data, settings) {
                 }
             ];
         }
-        return settings.mainValues.map((main, i) => ({name: main.name, value: data.mainValues[i]}));
+        return settings.mainValues.map((main, i) => ({name: main.name, value: toValue(main.type, data.mainValues[i])}));
     }
     return [
         {

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/selectionEvent.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/selectionEvent.js
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+import {getGroupValues, getSplitValues, getDataValues} from "./selectionData";
+
+const mapToFilter = d => [d.name, "==", d.value];
+
+export const raiseEvent = (node, data, settings) => {
+    const column_names = getDataValues(data, settings).map(d => d.name);
+    const groupFilters = getGroupValues(data, settings).map(mapToFilter);
+    const splitFilters = getSplitValues(data, settings).map(mapToFilter);
+
+    const filters = settings.filter.concat(groupFilters).concat(splitFilters);
+
+    node.dispatchEvent(
+        new CustomEvent("perspective-click", {
+            bubbles: true,
+            composed: true,
+            detail: {
+                column_names,
+                config: {filters},
+                row: data.row
+            }
+        })
+    );
+};
+
+export const selectionEvent = () => {
+    let settings = null;
+
+    const _event = selection => {
+        const node = selection.node();
+        selection.on("click", data => raiseEvent(node, data, settings));
+    };
+
+    _event.settings = (...args) => {
+        if (!args.length) {
+            return settings;
+        }
+        settings = args[0];
+        return _event;
+    };
+
+    return _event;
+};

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
@@ -1,8 +1,18 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
 import {select} from "d3";
 import {getChartElement} from "../plugin/root";
 import {getOrCreateElement, isElementOverflowing} from "../utils/utils";
 import tooltipTemplate from "../../html/tooltip.html";
 import {generateHtml} from "./generateHTML";
+import {selectionEvent} from "./selectionEvent";
 
 export const tooltip = () => {
     let alwaysShow = false;
@@ -34,6 +44,7 @@ export const tooltip = () => {
             selection.each(showTip);
         } else {
             selection.on("mouseover", showTip).on("mouseout", hideTip);
+            selectionEvent().settings(settings)(selection);
         }
     };
 


### PR DESCRIPTION
Reused tooltip code to extract relevant name-value data for currently selected node.
Added source row object to each data element so it can be sent back up in the event.
Added "filter" information to the settings so it can be included in the event.

Note that I've also updated the split-screen examples to handle events from the top chart and set the corresponding filter on the lower two.