### PR TITLE
Theme chart series from CSS and theme file

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/ohlcCandle.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/ohlcCandle.js
@@ -37,7 +37,6 @@ function ohlcCandle(seriesCanvas) {
 
         const upColor = colorScale()
             .domain(keys)
-            .defaultColors(["rgba(31, 119, 180)"])
             .mapFunction(setOpacity(1))();
 
         const legend = colorLegend()
@@ -100,6 +99,7 @@ function ohlcCandle(seriesCanvas) {
             .xScale(xScale)
             .yScale(yScale)
             .yValueName("closeValue")
+            .color(upColor)
             .data(data)
             .canvas(true);
 

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -12,6 +12,7 @@ import style from "../../less/chart.less";
 import perspectiveStyle from "../../less/perspective-view.less";
 import template from "../../html/d3fc-chart.html";
 import {areArraysEqualSimple} from "../utils/utils";
+import {initialiseStyles} from "../series/colorStyles";
 
 import {bindTemplate} from "@jpmorganchase/perspective-viewer/cjs/js/utils";
 
@@ -29,6 +30,8 @@ class D3FCChartElement extends HTMLElement {
         style.setAttribute("scope", "perspective-viewer");
         style.textContent = perspectiveStyle;
         this.shadowRoot.host.getRootNode().appendChild(style);
+
+        initialiseStyles(this._container);
     }
 
     render(chart, settings) {

--- a/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/areaSeries.js
@@ -12,9 +12,7 @@ export function areaSeries(settings, color) {
     let series = fc.seriesSvgArea();
 
     series = series.decorate(selection => {
-        if (color) {
-            selection.style("fill", d => color(d[0].key));
-        }
+        selection.style("fill", d => color(d[0].key));
     });
 
     return series

--- a/packages/perspective-viewer-d3fc/src/js/series/barSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/barSeries.js
@@ -14,9 +14,7 @@ export function barSeries(settings, color) {
 
     series = series.decorate(selection => {
         tooltip().settings(settings)(selection);
-        if (color) {
-            selection.style("fill", d => color(d.key));
-        }
+        selection.style("fill", d => color(d.key));
     });
 
     return fc

--- a/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
@@ -18,9 +18,7 @@ export function categoryPointSeries(settings, seriesKey, color, symbols) {
     }
 
     series.decorate(selection => {
-        if (color) {
-            selection.style("stroke", d => withoutOpacity(color(d.colorValue || seriesKey))).style("fill", d => withOpacity(color(d.colorValue || seriesKey)));
-        }
+        selection.style("stroke", d => withoutOpacity(color(d.colorValue || seriesKey))).style("fill", d => withOpacity(color(d.colorValue || seriesKey)));
     });
 
     return series.crossValue(d => d.crossValue).mainValue(d => d.mainValue);

--- a/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * Copyright (c) 2017, the Perspective Authors.
+ *
+ * This file is part of the Perspective library, distributed under the terms of
+ * the Apache License 2.0.  The full license can be found in the LICENSE file.
+ *
+ */
+
+import * as d3 from "d3";
+
+let initialised = false;
+export const colorStyles = {
+    scheme: []
+};
+
+export const initialiseStyles = container => {
+    if (!initialised) {
+        const selection = d3.select(container);
+        const chart = selection.append("svg").attr("class", "chart");
+
+        const data = ["series"];
+        for (let n = 1; n <= 10; n++) {
+            data.push(`series-${n}`);
+        }
+
+        const testElements = chart
+            .selectAll("circle")
+            .data(data)
+            .enter()
+            .append("circle")
+            .attr("class", d => d);
+
+        testElements.each((d, i, nodes) => {
+            const style = getComputedStyle(nodes[i]);
+            colorStyles[d] = style.getPropertyValue("fill");
+
+            if (i > 0) {
+                colorStyles.scheme.push(colorStyles[d]);
+            }
+        });
+
+        colorStyles.opacity = getOpacityFromColor(colorStyles.series);
+
+        chart.remove();
+        initialised = true;
+    }
+};
+
+const getOpacityFromColor = color => {
+    if (color.includes("rgba")) {
+        const rgbColors = color.substring(color.indexOf("(") + 1).split(",");
+        return parseFloat(rgbColors[3]);
+    }
+    return 1;
+};

--- a/packages/perspective-viewer-d3fc/src/js/series/lineSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/lineSeries.js
@@ -12,11 +12,9 @@ import {withoutOpacity} from "./seriesColors.js";
 export function lineSeries(settings, color) {
     let series = fc.seriesSvgLine();
 
-    if (color) {
-        series = series.decorate(selection => {
-            selection.style("stroke", d => withoutOpacity(color(d[0] && d[0].key)));
-        });
-    }
+    series = series.decorate(selection => {
+        selection.style("stroke", d => withoutOpacity(color(d[0] && d[0].key)));
+    });
 
     return series.crossValue(d => d.crossValue).mainValue(d => d.mainValue);
 }

--- a/packages/perspective-viewer-d3fc/src/js/series/ohlcCandleSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/ohlcCandleSeries.js
@@ -8,6 +8,7 @@
  */
 import * as fc from "d3fc";
 import {colorScale, setOpacity} from "../series/seriesColors";
+import {colorStyles} from "./colorStyles";
 
 const isUp = d => d.closeValue >= d.openValue;
 
@@ -15,10 +16,9 @@ export function ohlcCandleSeries(settings, seriesCanvas, upColor) {
     const domain = upColor.domain();
     const downColor = colorScale()
         .domain(domain)
-        .defaultColors(["rgba(255, 127, 14)"])();
-    const avgColor = colorScale()
-        .domain(domain)
-        .defaultColors(["rgba(31, 119, 180)"])();
+        .defaultColors([colorStyles["series-2"]])
+        .mapFunction(setOpacity(0.5))();
+    const avgColor = colorScale().domain(domain)();
 
     const series = seriesCanvas()
         .crossValue(d => d.crossValue)

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -24,15 +24,10 @@ export function pointSeriesCanvas(settings, seriesKey, size, color, symbols) {
     }
 
     series.decorate((context, d) => {
-        if (color) {
-            const colorValue = color(d.colorValue !== undefined ? d.colorValue : seriesKey);
+        const colorValue = color(d.colorValue !== undefined ? d.colorValue : seriesKey);
 
-            context.strokeStyle = withoutOpacity(colorValue);
-            context.fillStyle = withOpacity(colorValue);
-        } else {
-            context.strokeStyle = "rgb(31, 119, 180)";
-            context.fillStyle = "rgba(31, 119, 180, 0.5)";
-        }
+        context.strokeStyle = withoutOpacity(colorValue);
+        context.fillStyle = withOpacity(colorValue);
     });
 
     return series;

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -8,6 +8,7 @@
  */
 import * as d3 from "d3";
 import {groupFromKey} from "./seriesKey";
+import {colorStyles} from "./colorStyles";
 
 export function seriesColors(settings) {
     const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
@@ -31,13 +32,13 @@ export function seriesColorsFromGroups(settings) {
 
 export function colorScale() {
     let domain = null;
-    let defaultColors = null;
+    let defaultColors = [colorStyles.series];
     let mapFunction = withOpacity;
 
     const colors = () => {
         if (defaultColors || domain.length > 1) {
-            const range = domain.length > 1 ? d3.schemeCategory10.map(mapFunction) : defaultColors;
-            return d3.scaleOrdinal(range).domain(domain);
+            const range = domain.length > 1 ? colorStyles.scheme : defaultColors;
+            return d3.scaleOrdinal(range.map(mapFunction)).domain(domain);
         }
         return null;
     };
@@ -74,7 +75,7 @@ export function withoutOpacity(color) {
 }
 
 export function withOpacity(color) {
-    return setOpacity(0.5)(color);
+    return setOpacity(colorStyles.opacity)(color);
 }
 
 export function setOpacity(opacity) {

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -63,21 +63,52 @@
         }
 
         & .bar {
-            fill: rgba(31, 119, 180, 0.5);
+            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
         }
         & .line {
-            stroke: rgba(31, 119, 180, 0.5);
+            stroke: var(--d3fc-series, rgb(31, 119, 180));
         }
-        & .point {
-            fill: rgba(31, 119, 180, 0.5);
-            stroke: rgb(31, 119, 180);
+        & .point, & .series {
+            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
+            stroke: var(--d3fc-series, rgb(31, 119, 180));
         }
         & .area {
-            fill: rgba(31, 119, 180, 0.5);
+            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
         }
 
         & .nearbyTip {
-            fill: rgba(31, 119, 180, 0.5);
+            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
+        }
+
+        & .series-1 {
+            fill: var(--d3fc-series-1, #0366d6);
+        }
+        & .series-2 {
+            fill: var(--d3fc-series-2, #ff7f0e);
+        }
+        & .series-3 {
+            fill: var(--d3fc-series-3, #2ca02c);
+        }
+        & .series-4 {
+            fill: var(--d3fc-series-4, #d62728);
+        }
+        & .series-5 {
+            fill: var(--d3fc-series-5, #9467bd);
+        }
+        & .series-6 {
+            fill: var(--d3fc-series-6, #8c564b);
+        }
+        & .series-7 {
+            fill: var(--d3fc-series-7, #e377c2);
+        }
+        & .series-8 {
+            fill: var(--d3fc-series-8, #7f7f7f);
+        }
+        & .series-9 {
+            fill: var(--d3fc-series-9, #bcbd22);
+        }
+        & .series-10 {
+            fill: var(--d3fc-series-10, #17becf);
         }
     }
 
@@ -105,8 +136,8 @@
                 cursor: pointer;
 
                 & path {
-                    fill: rgba(31, 119, 180, 0.5);
-                    stroke: rgb(31, 119, 180);
+                    fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
+                    stroke: var(--d3fc-series, rgb(31, 119, 180));
                 }
                 &.hidden path {
                     fill: rgba(204, 204, 204, 0.5);

--- a/packages/perspective-viewer/src/themes/material.dark.less
+++ b/packages/perspective-viewer/src/themes/material.dark.less
@@ -60,7 +60,18 @@ perspective-viewer {
     --d3fc-axis--lines: rgb(85, 85, 85);
     --d3fc-tooltip--background: #333333;
     --d3fc-tooltip--color: rgb(207, 216, 220);
-
+    --d3fc-series: rgb(31, 119, 180, 0.8);
+    --d3fc-series-1: #0366d6;
+    --d3fc-series-2: #ff7f0e;
+    --d3fc-series-3: #2ca02c;
+    --d3fc-series-4: #d62728;
+    --d3fc-series-5: #9467bd;
+    --d3fc-series-6: #8c564b;
+    --d3fc-series-7: #e377c2;
+    --d3fc-series-8: #7f7f7f;
+    --d3fc-series-9: #bcbd22;
+    --d3fc-series-10: #17becf;
+    
     --highcharts-heatmap-gradient-full: linear-gradient(
         #feeb65 0%,
         #e4521b 22.5%,


### PR DESCRIPTION
Initialise by briefly creating svg elements to get the css styles for all series. Then use those styles for the colour ranges.

Colour ranges now always have a default, so no need to fall back on hard-coded or un-styled.

Get "opacity" level (for fill areas etc) from the base "series" setting, so it can be applied at runtime. This allows the themes to set different opacity levels.