### PR TITLE
 Put color styles in settings so that they can be scoped to a chart

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/ohlcCandle.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/ohlcCandle.js
@@ -37,6 +37,7 @@ function ohlcCandle(seriesCanvas) {
 
         const upColor = colorScale()
             .domain(keys)
+            .settings(settings)
             .mapFunction(setOpacity(1))();
 
         const legend = colorLegend()

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -30,8 +30,6 @@ class D3FCChartElement extends HTMLElement {
         style.setAttribute("scope", "perspective-viewer");
         style.textContent = perspectiveStyle;
         this.shadowRoot.host.getRootNode().appendChild(style);
-
-        initialiseStyles(this._container);
     }
 
     render(chart, settings) {
@@ -39,6 +37,7 @@ class D3FCChartElement extends HTMLElement {
 
         this._chart = chart;
         this._settings = this._configureSettings(this._settings, settings);
+        initialiseStyles(this._container, this._settings);
         this.draw();
 
         if (window.navigator.userAgent.indexOf("Edge") > -1) {
@@ -78,7 +77,8 @@ class D3FCChartElement extends HTMLElement {
             if (areArraysEqualSimple(oldValues, newValues)) return {...oldSettings, data: newSettings.data};
         }
         this.remove();
-        return newSettings;
+        const {colorStyles} = oldSettings || {};
+        return {...newSettings, colorStyles};
     }
 }
 

--- a/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
@@ -7,35 +7,23 @@
  *
  */
 
-import * as d3 from "d3";
-
 let initialised = false;
 export const colorStyles = {};
 
 export const initialiseStyles = (container, settings) => {
     if (!initialised || !settings.colorStyles) {
-        const selection = d3.select(container);
-        const chart = selection.append("svg").attr("class", "chart");
-
         const data = ["series"];
         for (let n = 1; n <= 10; n++) {
             data.push(`series-${n}`);
         }
 
-        const testElements = chart
-            .selectAll("circle")
-            .data(data)
-            .enter()
-            .append("circle")
-            .attr("class", d => d);
-
         const styles = {
             scheme: []
         };
 
-        testElements.each((d, i, nodes) => {
-            const style = getComputedStyle(nodes[i]);
-            styles[d] = style.getPropertyValue("fill");
+        const computed = computedStyle(container);
+        data.forEach((d, i) => {
+            styles[d] = computed(`--d3fc-${d}`);
 
             if (i > 0) {
                 styles.scheme.push(styles[d]);
@@ -43,8 +31,6 @@ export const initialiseStyles = (container, settings) => {
         });
 
         styles.opacity = getOpacityFromColor(styles.series);
-
-        chart.remove();
 
         if (!initialised) {
             Object.keys(styles).forEach(p => {
@@ -62,4 +48,13 @@ const getOpacityFromColor = color => {
         return parseFloat(rgbColors[3]);
     }
     return 1;
+};
+
+const computedStyle = container => {
+    if (window.ShadyCSS) {
+        return d => window.ShadyCSS.getComputedStyleValue(container, d);
+    } else {
+        const containerStyles = getComputedStyle(container);
+        return d => containerStyles.getPropertyValue(d);
+    }
 };

--- a/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/colorStyles.js
@@ -10,12 +10,10 @@
 import * as d3 from "d3";
 
 let initialised = false;
-export const colorStyles = {
-    scheme: []
-};
+export const colorStyles = {};
 
-export const initialiseStyles = container => {
-    if (!initialised) {
+export const initialiseStyles = (container, settings) => {
+    if (!initialised || !settings.colorStyles) {
         const selection = d3.select(container);
         const chart = selection.append("svg").attr("class", "chart");
 
@@ -31,19 +29,30 @@ export const initialiseStyles = container => {
             .append("circle")
             .attr("class", d => d);
 
+        const styles = {
+            scheme: []
+        };
+
         testElements.each((d, i, nodes) => {
             const style = getComputedStyle(nodes[i]);
-            colorStyles[d] = style.getPropertyValue("fill");
+            styles[d] = style.getPropertyValue("fill");
 
             if (i > 0) {
-                colorStyles.scheme.push(colorStyles[d]);
+                styles.scheme.push(styles[d]);
             }
         });
 
-        colorStyles.opacity = getOpacityFromColor(colorStyles.series);
+        styles.opacity = getOpacityFromColor(styles.series);
 
         chart.remove();
-        initialised = true;
+
+        if (!initialised) {
+            Object.keys(styles).forEach(p => {
+                colorStyles[p] = styles[p];
+            });
+            initialised = true;
+        }
+        settings.colorStyles = styles;
     }
 };
 

--- a/packages/perspective-viewer-d3fc/src/js/series/ohlcCandleSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/ohlcCandleSeries.js
@@ -8,7 +8,6 @@
  */
 import * as fc from "d3fc";
 import {colorScale, setOpacity} from "../series/seriesColors";
-import {colorStyles} from "./colorStyles";
 
 const isUp = d => d.closeValue >= d.openValue;
 
@@ -16,9 +15,12 @@ export function ohlcCandleSeries(settings, seriesCanvas, upColor) {
     const domain = upColor.domain();
     const downColor = colorScale()
         .domain(domain)
-        .defaultColors([colorStyles["series-2"]])
+        .settings(settings)
+        .defaultColors([settings.colorStyles["series-2"]])
         .mapFunction(setOpacity(0.5))();
-    const avgColor = colorScale().domain(domain)();
+    const avgColor = colorScale()
+        .settings(settings)
+        .domain(domain)();
 
     const series = seriesCanvas()
         .crossValue(d => d.crossValue)

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -13,7 +13,9 @@ import {colorStyles} from "./colorStyles";
 export function seriesColors(settings) {
     const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
     const domain = Object.keys(col).filter(k => k !== "__ROW_PATH__");
-    return colorScale().domain(domain)();
+    return colorScale()
+        .settings(settings)
+        .domain(domain)();
 }
 
 export function seriesColorsFromGroups(settings) {
@@ -27,17 +29,22 @@ export function seriesColorsFromGroups(settings) {
             }
         }
     });
-    return colorScale().domain(domain)();
+    return colorScale()
+        .settings(settings)
+        .domain(domain)();
 }
 
 export function colorScale() {
     let domain = null;
-    let defaultColors = [colorStyles.series];
+    let defaultColors = null;
     let mapFunction = withOpacity;
+    let settings = {colorStyles};
 
     const colors = () => {
-        if (defaultColors || domain.length > 1) {
-            const range = domain.length > 1 ? colorStyles.scheme : defaultColors;
+        const styles = settings.colorStyles;
+        const defaults = defaultColors || [styles.series];
+        if (defaults || domain.length > 1) {
+            const range = domain.length > 1 ? styles.scheme : defaults;
             return d3.scaleOrdinal(range.map(mapFunction)).domain(domain);
         }
         return null;
@@ -64,6 +71,14 @@ export function colorScale() {
             return mapFunction;
         }
         mapFunction = args[0];
+        return colors;
+    };
+
+    colors.settings = (...args) => {
+        if (!args.length) {
+            return settings;
+        }
+        settings = args[0];
         return colors;
     };
 

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -62,24 +62,13 @@
             white-space: nowrap;
         }
 
-        & .bar {
-            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
-        }
-        & .line {
-            stroke: var(--d3fc-series, rgb(31, 119, 180));
-        }
-        & .point, & .series {
-            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
-            stroke: var(--d3fc-series, rgb(31, 119, 180));
-        }
-        & .area {
-            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
-        }
-
         & .nearbyTip {
             fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
         }
 
+        & .series {
+            fill: var(--d3fc-series, rgba(31, 119, 180, 0.5));
+        }
         & .series-1 {
             fill: var(--d3fc-series-1, #0366d6);
         }

--- a/packages/perspective-viewer-d3fc/src/less/perspective-view.less
+++ b/packages/perspective-viewer-d3fc/src/less/perspective-view.less
@@ -1,3 +1,17 @@
+:host {
+  --d3fc-series: rgba(31, 119, 180, 0.5);
+  --d3fc-series-1: #0366d6;
+  --d3fc-series-2: #ff7f0e;
+  --d3fc-series-3: #2ca02c;
+  --d3fc-series-4: #d62728;
+  --d3fc-series-5: #9467bd;
+  --d3fc-series-6: #8c564b;
+  --d3fc-series-7: #e377c2;
+  --d3fc-series-8: #7f7f7f;
+  --d3fc-series-9: #bcbd22;
+  --d3fc-series-10: #17becf;
+}
+
 :host([view=d3_xy_scatter]), :host([view=d3_candlestick]), :host([view=d3_ohlc]) {
  & #app {
    &.columns_horizontal #side_panel #inactive_columns {

--- a/packages/perspective-viewer/src/themes/material.dark.less
+++ b/packages/perspective-viewer/src/themes/material.dark.less
@@ -60,7 +60,7 @@ perspective-viewer {
     --d3fc-axis--lines: rgb(85, 85, 85);
     --d3fc-tooltip--background: #333333;
     --d3fc-tooltip--color: rgb(207, 216, 220);
-    --d3fc-series: rgb(31, 119, 180, 0.8);
+    --d3fc-series: rgba(31, 119, 180, 0.8);
     --d3fc-series-1: #0366d6;
     --d3fc-series-2: #ff7f0e;
     --d3fc-series-3: #2ca02c;


### PR DESCRIPTION
Allows us to put multiple charts on a single page, where theme settings apply to only some of them.
The split-screen examples have been updated to show gold/silver/bronze on the middle chart only

Use `ShadyCSS` component to get style variables directly
This is the same as Highcharts currently uses.
Avoids having to create svg and dom elements to get the styles.
Requires that the default style variables are set in the perspective-viewer layer.