### PR TITLE
Hide labels that would be clipped by the window bounds

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/legend/styling/draggableComponent.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/styling/draggableComponent.js
@@ -9,7 +9,7 @@
 
 import * as d3 from "d3";
 import {isElementOverflowing} from "../../utils/utils";
-import {getChartElement} from "../../plugin/root";
+import {getChartContainer} from "../../plugin/root";
 
 const margin = 10;
 const resizeForDraggingEvent = "resize.for-dragging";
@@ -63,7 +63,7 @@ function pinNodeToTopRight(node) {
 function isNodeInTopRight(node) {
     const nodeRect = node.getBoundingClientRect();
     const containerRect = d3
-        .select(getChartElement(node).getContainer())
+        .select(getChartContainer(node))
         .node()
         .getBoundingClientRect();
 
@@ -74,7 +74,7 @@ function isNodeInTopRight(node) {
 
 function enforceContainerBoundaries(innerNode, offsetX, offsetY) {
     const chartNodeRect = d3
-        .select(getChartElement(innerNode).getContainer())
+        .select(getChartContainer(innerNode))
         .node()
         .getBoundingClientRect();
 

--- a/packages/perspective-viewer-d3fc/src/js/plugin/root.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/root.js
@@ -10,3 +10,7 @@
 export function getChartElement(element) {
     return element.getRootNode().host;
 }
+
+export function getChartContainer(element) {
+    return getChartElement(element).getContainer();
+}

--- a/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
+++ b/packages/perspective-viewer-d3fc/src/js/tooltip/tooltip.js
@@ -8,7 +8,7 @@
  */
 
 import {select} from "d3";
-import {getChartElement} from "../plugin/root";
+import {getChartContainer} from "../plugin/root";
 import {getOrCreateElement, isElementOverflowing} from "../utils/utils";
 import tooltipTemplate from "../../html/tooltip.html";
 import {generateHtml} from "./generateHTML";
@@ -27,7 +27,7 @@ export const tooltip = () => {
             return;
         }
 
-        const container = select(getChartElement(node).getContainer());
+        const container = select(getChartContainer(node));
         tooltipDiv = getTooltipDiv(container);
 
         const showTip = (data, i, nodes) => {


### PR DESCRIPTION
Check whether labels are outside of window bounds, and hide them.
Also added support for fully rotating (90 degrees) when there are a very large number of labels, similar to Highcharts.