### PR TITLE
Improved colour-legend display and labels

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/legend/colorRangeLegend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/colorRangeLegend.js
@@ -23,7 +23,10 @@ export function colorRangeLegend() {
     const formatFunc = d => (Number.isInteger(d) ? d3.format(",.0f")(d) : d3.format(",.2f")(d));
 
     function legend(container) {
-        const domain = scale.domain();
+        const domain = scale
+            .copy()
+            .nice()
+            .domain();
         const paddedDomain = fc
             .extentLinear()
             .pad([0.1, 0.1])
@@ -34,6 +37,7 @@ export function colorRangeLegend() {
         const yScale = d3
             .scaleLinear()
             .domain(paddedDomain)
+            .nice()
             .range([height, 0]);
 
         const svgBar = fc

--- a/packages/perspective-viewer-d3fc/src/js/legend/colorRangeLegend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/colorRangeLegend.js
@@ -11,8 +11,8 @@ import * as fc from "d3fc";
 import {getOrCreateElement} from "../utils/utils";
 
 export function colorRangeLegend() {
-    const width = 100;
-    const height = 150;
+    const width = 90;
+    const height = 200;
     let scale = null;
 
     const xScale = d3
@@ -37,7 +37,6 @@ export function colorRangeLegend() {
         const yScale = d3
             .scaleLinear()
             .domain(paddedDomain)
-            .nice()
             .range([height, 0]);
 
         const svgBar = fc
@@ -51,16 +50,19 @@ export function colorRangeLegend() {
                 selection.selectAll("path").style("fill", d => scale(d));
             });
 
+        const middle = domain[0] < 0 && domain[1] > 0 ? 0 : Math.round((domain[1] + domain[0]) / 2);
+        const tickValues = [...domain, middle];
+
         const axisLabel = fc
             .axisRight(yScale)
-            .tickValues([...domain, (domain[1] + domain[0]) / 2])
+            .tickValues(tickValues)
             .tickSizeOuter(0)
             .tickFormat(d => formatFunc(d));
 
         const legendSelection = getOrCreateElement(container, "div.legend-container", () =>
             container
                 .append("div")
-                .attr("class", "legend-container")
+                .attr("class", "legend-container legend-color")
                 .style("z-index", "2")
         );
 

--- a/packages/perspective-viewer-d3fc/src/js/legend/scrollableLegend.js
+++ b/packages/perspective-viewer-d3fc/src/js/legend/scrollableLegend.js
@@ -8,24 +8,19 @@
  */
 import * as d3Legend from "d3-svg-legend";
 import {rebindAll} from "d3fc";
-import {areArraysEqualSimple, getOrCreateElement} from "../utils/utils";
+import {getOrCreateElement} from "../utils/utils";
 import legendControlsTemplate from "../../html/legend-controls.html";
 import {cropCellContents} from "./styling/cropCellContents";
 
-export default fromLegend => {
+export default (fromLegend, settings) => {
     const legend = fromLegend || d3Legend.legendColor();
-    let domain = [];
     let pageCount = 1;
     let pageSize = 15;
-    let pageIndex = 0;
+    let pageIndex = settings.legend ? settings.legend.pageIndex : 0;
     let decorate = () => {};
 
     const scrollableLegend = selection => {
-        const newDomain = legend.scale().domain();
-        if (!areArraysEqualSimple(domain, newDomain)) {
-            pageIndex = 0;
-            domain = newDomain;
-        }
+        const domain = legend.scale().domain();
         pageCount = Math.ceil(domain.length / pageSize);
 
         render(selection);
@@ -48,7 +43,7 @@ export default fromLegend => {
             .attr("class", pageIndex === 0 ? "disabled" : "")
             .on("click", () => {
                 if (pageIndex > 0) {
-                    pageIndex--;
+                    setPage(pageIndex - 1);
                     render(selection);
                 }
             });
@@ -58,7 +53,7 @@ export default fromLegend => {
             .attr("class", pageIndex >= pageCount - 1 ? "disabled" : "")
             .on("click", () => {
                 if (pageIndex < pageCount - 1) {
-                    pageIndex++;
+                    setPage(pageIndex + 1);
                     render(selection);
                 }
             });
@@ -78,6 +73,11 @@ export default fromLegend => {
         legendElement.attr("height", cellSize.height + 20);
 
         decorate(selection);
+    };
+
+    const setPage = index => {
+        pageIndex = index;
+        settings.legend = {pageIndex};
     };
 
     const cellFilter = () => {
@@ -103,5 +103,6 @@ export default fromLegend => {
     };
 
     rebindAll(scrollableLegend, legend);
+
     return scrollableLegend;
 };

--- a/packages/perspective-viewer-d3fc/src/less/chart.less
+++ b/packages/perspective-viewer-d3fc/src/less/chart.less
@@ -20,7 +20,7 @@
         overflow: hidden;
 
         &.d3_heatmap {
-            padding-right: 165px;
+            padding-right: 105px;
         }
 
         & .x-label {
@@ -111,6 +111,10 @@
         right: 15px;
         left: auto;
         width: 150px;
+
+        &.legend-color {
+            width: 90px;
+        }
 
         &[borderbox-on-hover="true"] {
             &:hover {


### PR DESCRIPTION
Use a "nice" number range for display purpose only (doesn't affect the actual colours used).
Give the colour legend a bit more height, but less width, which it doesn't need.

Prevents legends from different charts interfering with each other.
Stores `pageIndex` in settings to preserve page position.
