### PR TITLE
sunburst - add labels, don't display if no crossValue is supplied

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
@@ -14,6 +14,8 @@ import {colorRangeLegend} from "../legend/colorRangeLegend";
 import {tooltip} from "../tooltip/tooltip";
 
 function sunburst(container, settings) {
+    if (settings.crossValues.length === 0) return;
+
     const sunburstData = treeData(settings);
     const {width: containerWidth, height: containerHeight} = container.node().getBoundingClientRect();
 

--- a/packages/perspective-viewer-d3fc/src/less/perspective-view.less
+++ b/packages/perspective-viewer-d3fc/src/less/perspective-view.less
@@ -31,7 +31,7 @@
   );
 }
 
-:host([view=d3_xy_scatter]), :host([view=d3_candlestick]), :host([view=d3_ohlc]) {
+:host([view=d3_xy_scatter]), :host([view=d3_candlestick]), :host([view=d3_ohlc]), :host([view=d3_sunburst]) {
  & #app {
    &.columns_horizontal #side_panel #inactive_columns {
      padding-top:28px
@@ -79,6 +79,18 @@
 
    &:nth-child(4):before {
      content:"Low"
+   }
+ }
+}
+
+:host([view=d3_sunburst]) {
+ & #app #side_panel #active_columns perspective-row {
+   &:nth-child(1):before {
+     content:"Size"
+   }
+
+   &:nth-child(2):before {
+     content:"Color"
    }
  }
 }


### PR DESCRIPTION
- Add labels to the values for sunburst
- If no crossValue is supplied, do not draw the sunburst (otherwise the legend is displayed for an empty chart)