### PR TITLE
Allow for 2-column display when only 2 charts (#151)

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/sunburst.js
@@ -20,7 +20,7 @@ function sunburst(container, settings) {
     const {width: containerWidth, height: containerHeight} = container.node().getBoundingClientRect();
 
     const minSize = 500;
-    const cols = sunburstData.length === 1 ? 1 : Math.floor(containerWidth / minSize);
+    const cols = Math.min(sunburstData.length, Math.floor(containerWidth / minSize));
     const rows = Math.ceil(sunburstData.length / cols);
     const containerSize = {
         width: containerWidth / cols,


### PR DESCRIPTION
Previously, it would allocate 3 or more columns (space allowing), even if there were only two charts to show.