### PR TITLE
Support for live theme changes

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -67,11 +67,10 @@ class D3FCChartElement extends HTMLElement {
         if (oldSettings) {
             const oldValues = [oldSettings.crossValues, oldSettings.mainValues, oldSettings.splitValues];
             const newValues = [newSettings.crossValues, newSettings.mainValues, newSettings.splitValues];
-            if (areArraysEqualSimple(oldValues, newValues)) return {...oldSettings, data: newSettings.data};
+            if (areArraysEqualSimple(oldValues, newValues)) return {...oldSettings, data: newSettings.data, colorStyles: null};
         }
         this.remove();
-        const {colorStyles} = oldSettings || {};
-        return {...newSettings, colorStyles};
+        return newSettings;
     }
 }
 

--- a/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/categoryPointSeries.js
@@ -12,13 +12,14 @@ import {fromDomain} from "./seriesSymbols";
 
 export function categoryPointSeries(settings, seriesKey, color, symbols) {
     let series = fc.seriesSvgPoint().size(100);
+    const opacity = settings.colorStyles && settings.colorStyles.opacity;
 
     if (symbols) {
         series.type(symbols(seriesKey));
     }
 
     series.decorate(selection => {
-        selection.style("stroke", d => withoutOpacity(color(d.colorValue || seriesKey))).style("fill", d => withOpacity(color(d.colorValue || seriesKey)));
+        selection.style("stroke", d => withoutOpacity(color(d.colorValue || seriesKey))).style("fill", d => withOpacity(color(d.colorValue || seriesKey), opacity));
     });
 
     return series.crossValue(d => d.crossValue).mainValue(d => d.mainValue);

--- a/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/pointSeriesCanvas.js
@@ -25,9 +25,10 @@ export function pointSeriesCanvas(settings, seriesKey, size, color, symbols) {
 
     series.decorate((context, d) => {
         const colorValue = color(d.colorValue !== undefined ? d.colorValue : seriesKey);
+        const opacity = settings.colorStyles && settings.colorStyles.opacity;
 
         context.strokeStyle = withoutOpacity(colorValue);
-        context.fillStyle = withOpacity(colorValue);
+        context.fillStyle = withOpacity(colorValue, opacity);
     });
 
     return series;

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesColors.js
@@ -8,7 +8,6 @@
  */
 import * as d3 from "d3";
 import {groupFromKey} from "./seriesKey";
-import {colorStyles} from "./colorStyles";
 
 export function seriesColors(settings) {
     const col = settings.data && settings.data.length > 0 ? settings.data[0] : {};
@@ -37,8 +36,8 @@ export function seriesColorsFromGroups(settings) {
 export function colorScale() {
     let domain = null;
     let defaultColors = null;
-    let mapFunction = withOpacity;
-    let settings = {colorStyles};
+    let settings = {};
+    let mapFunction = d => withOpacity(d, settings.colorStyles && settings.colorStyles.opacity);
 
     const colors = () => {
         const styles = settings.colorStyles;
@@ -89,8 +88,8 @@ export function withoutOpacity(color) {
     return setOpacity(1)(color);
 }
 
-export function withOpacity(color) {
-    return setOpacity(colorStyles.opacity)(color);
+export function withOpacity(color, opacity = 0.5) {
+    return setOpacity(opacity)(color);
 }
 
 export function setOpacity(opacity) {

--- a/packages/perspective-viewer-d3fc/src/js/series/seriesRange.js
+++ b/packages/perspective-viewer-d3fc/src/js/series/seriesRange.js
@@ -23,16 +23,38 @@ export function seriesColorRange(settings, data, valueName, customExtent) {
         domain()
             .valueName(valueName)
             .pad([0, 0])(data);
-    let interpolator = settings.colorStyles.interpolator.full;
+    let gradient = settings.colorStyles.gradient.full;
 
     if (extent[0] >= 0) {
-        interpolator = settings.colorStyles.interpolator.positive;
+        gradient = settings.colorStyles.gradient.positive;
     } else if (extent[1] <= 0) {
-        interpolator = settings.colorStyles.interpolator.negative;
+        gradient = settings.colorStyles.gradient.negative;
     } else {
         const maxVal = Math.max(-extent[0], extent[1]);
         extent = [-maxVal, maxVal];
     }
 
+    const interpolator = multiInterpolator(gradient);
     return d3.scaleSequential(interpolator).domain(extent);
 }
+
+const multiInterpolator = gradientPairs => {
+    // A new interpolator that calls through to a set of
+    // interpolators between each value/color pair
+    const interpolators = gradientPairs.slice(1).map((p, i) => d3.interpolate(gradientPairs[i][1], p[1]));
+    return value => {
+        const index = gradientPairs.findIndex((p, i) => i < gradientPairs.length - 1 && value <= gradientPairs[i + 1][0] && value > p[0]);
+        if (index === -1) {
+            if (value <= gradientPairs[0][0]) {
+                return gradientPairs[0][1];
+            }
+            return gradientPairs[gradientPairs.length - 1][1];
+        }
+
+        const interpolator = interpolators[index];
+        const [value1] = gradientPairs[index];
+        const [value2] = gradientPairs[index + 1];
+
+        return interpolator((value - value1) / (value2 - value1));
+    };
+};


### PR DESCRIPTION
Don't store theme settings between renders (still put them in settings, but clear and reload when we re-render).
Remove remaining references to global "colorStyles" object (always use settings)
Calculate `interpolator` from gradient as required, rather than all the time.