### PR TITLE
Allow settings to be restored before draw

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/plugin.js
@@ -56,7 +56,7 @@ function drawChart(chart) {
     };
 }
 
-function createOrUpdateChart(div, chart, settings) {
+function getOrCreatePluginElement() {
     let perspective_d3fc_element;
     this[PRIVATE] = this[PRIVATE] || {};
     if (!this[PRIVATE].chart) {
@@ -64,6 +64,11 @@ function createOrUpdateChart(div, chart, settings) {
     } else {
         perspective_d3fc_element = this[PRIVATE].chart;
     }
+    return perspective_d3fc_element;
+}
+
+function createOrUpdateChart(div, chart, settings) {
+    const perspective_d3fc_element = getOrCreatePluginElement.call(this);
 
     if (!document.body.contains(perspective_d3fc_element)) {
         div.innerHTML = "";
@@ -95,10 +100,8 @@ function save() {
 }
 
 function restore(config) {
-    if (this[PRIVATE] && this[PRIVATE].chart) {
-        const perspective_d3fc_element = this[PRIVATE].chart;
-        perspective_d3fc_element.setSettings(config);
-    }
+    const perspective_d3fc_element = getOrCreatePluginElement.call(this);
+    perspective_d3fc_element.setSettings(config);
 }
 
 if (!Element.prototype.matches) {

--- a/packages/perspective-viewer-d3fc/src/js/plugin/template.js
+++ b/packages/perspective-viewer-d3fc/src/js/plugin/template.js
@@ -19,10 +19,15 @@ const styleWithD3FC = `${style}${getD3FCStyles()}`;
 
 @bindTemplate(template, styleWithD3FC) // eslint-disable-next-line no-unused-vars
 class D3FCChartElement extends HTMLElement {
-    connectedCallback() {
-        this._container = this.shadowRoot.querySelector(".chart");
+    constructor() {
+        super();
         this._chart = null;
         this._settings = null;
+    }
+
+    connectedCallback() {
+        console.log("connected callback");
+        this._container = this.shadowRoot.querySelector(".chart");
     }
 
     render(chart, settings) {
@@ -87,6 +92,10 @@ class D3FCChartElement extends HTMLElement {
     }
 
     _configureSettings(oldSettings, newSettings) {
+        if (oldSettings && !oldSettings.data) {
+            // Combine with the restored settings
+            return {...oldSettings, ...newSettings};
+        }
         if (oldSettings) {
             const oldValues = [oldSettings.crossValues, oldSettings.mainValues, oldSettings.splitValues];
             const newValues = [newSettings.crossValues, newSettings.mainValues, newSettings.splitValues];


### PR DESCRIPTION
This makes it possible to do a single draw cycle, rather than have to restore settings later and do draw-restore-redraw.