### PR TITLE
Rename charts

### DIFF
--- a/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/treemap.js
@@ -61,7 +61,7 @@ function treemap(container, settings) {
 
 treemap.plugin = {
     type: "d3_treemap",
-    name: "[D3] Treemap",
+    name: "Treemap",
     max_size: 25000,
     initial: {
         type: "number",

--- a/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
+++ b/packages/perspective-viewer-d3fc/src/js/charts/xy-scatter.js
@@ -94,7 +94,7 @@ function xyScatter(container, settings) {
 }
 xyScatter.plugin = {
     type: "d3_xy_scatter",
-    name: "X/Y Scatter",
+    name: "X/Y Scatter Chart",
     max_size: 25000,
     initial: {
         type: "number",


### PR DESCRIPTION
Most charts have identical name values to the Highcharts equivalents. Treemap and X/Y Scatter are slightly different. These have been updated to match Highcharts for consistency.